### PR TITLE
Remove references to log4tango library

### DIFF
--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/projects/VC10/VC10Utils.java
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/projects/VC10/VC10Utils.java
@@ -153,7 +153,6 @@ public class VC10Utils {
 				tangoLibraryName("COS4",         mode, shared) +
 				tangoLibraryName("omnithread",   mode, shared) +
 				tangoLibraryName("tango",        mode, false) +
-				tangoLibraryName("log4tango",    mode, false) +
 				tangoLibraryName("zmq",          mode, false);
 	}
 

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/projects/VC12/VC12Utils.java
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/projects/VC12/VC12Utils.java
@@ -143,7 +143,6 @@ public class VC12Utils {
 				tangoLibraryName("COS4",         mode, shared) +
 				tangoLibraryName("omnithread",   mode, shared) +
 				tangoLibraryName("tango",        mode, false) +
-				tangoLibraryName("log4tango",    mode, false) +
 				tangoLibraryName("zmq",          mode, false);
 	}
 

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/projects/VC9/VC9_Project.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/projects/VC9/VC9_Project.xtend
@@ -271,7 +271,7 @@ class VC9_Project {
 					<Tool Name="VCLinkerTool"
 						IgnoreImportLibrary="false"
 						UseLibraryDependencyInputs="false"
-						AdditionalDependencies="$(SolutionName)d.lib omniORB4d.lib omniDynamic4d.lib COS4d.lib omnithreadd.lib tangod.lib zmqd.lib log4tangod.lib comctl32.lib ws2_32.lib mswsock.lib advapi32.lib"
+						AdditionalDependencies="$(SolutionName)d.lib omniORB4d.lib omniDynamic4d.lib COS4d.lib omnithreadd.lib tangod.lib zmqd.lib comctl32.lib ws2_32.lib mswsock.lib advapi32.lib"
 						ShowProgress="0"
 						OutputFile="$(OutDir)\$(SolutionName).exe"
 						LinkIncremental="0"
@@ -325,7 +325,7 @@ class VC9_Project {
 					<Tool Name="VCResourceCompilerTool" />
 					<Tool Name="VCPreLinkEventTool" />
 					<Tool Name="VCLinkerTool"
-						AdditionalDependencies="$(SolutionName).lib omniORB4.lib omniDynamic4.lib COS4.lib omnithread.lib tango.lib zmq.lib log4tango.lib comctl32.lib ws2_32.lib mswsock.lib advapi32.lib"
+						AdditionalDependencies="$(SolutionName).lib omniORB4.lib omniDynamic4.lib COS4.lib omnithread.lib tango.lib zmq.lib comctl32.lib ws2_32.lib mswsock.lib advapi32.lib"
 						OutputFile="$(OutDir)\$(SolutionName).exe"
 						LinkIncremental="0"
 						AdditionalLibraryDirectories="&quot;..\lib\win32\release&quot;;&quot;$(TANGO_ROOT)\win32\lib\vc9&quot;;&quot;$(TANGO_ROOT)\classes\win32\lib\vc9&quot;"
@@ -416,7 +416,7 @@ class VC9_Project {
 						CommandLine=""
 						ExcludedFromBuild="false" />
 					<Tool Name="VCLinkerTool"
-						AdditionalDependencies="omniORB4_rtd.lib omniDynamic4_rtd.lib COS4_rtd.lib omnithread_rtd.lib tangod.lib log4tangod.lib comctl32.lib ws2_32.lib"
+						AdditionalDependencies="omniORB4_rtd.lib omniDynamic4_rtd.lib COS4_rtd.lib omnithread_rtd.lib tangod.lib comctl32.lib ws2_32.lib"
 						ShowProgress="0"
 						OutputFile="$(OutDir)/$(SolutionName)d.dll"
 						Version="1.0"
@@ -470,7 +470,7 @@ class VC9_Project {
 					<Tool Name="VCResourceCompilerTool" />
 					<Tool Name="VCPreLinkEventTool" />
 					<Tool Name="VCLinkerTool"
-						AdditionalDependencies="omniORB4_rt.lib omniDynamic4_rt.lib COS4_rt.lib omnithread_rt.lib tango.lib log4tango.lib comctl32.lib ws2_32.lib"
+						AdditionalDependencies="omniORB4_rt.lib omniDynamic4_rt.lib COS4_rt.lib omnithread_rt.lib tango.lib comctl32.lib ws2_32.lib"
 						ShowProgress="0"
 						OutputFile="$(OutDir)/$(SolutionName).dll"
 						LinkIncremental="2"
@@ -570,7 +570,7 @@ class VC9_Project {
 						Culture="1036" />
 					<Tool Name="VCPreLinkEventTool" />
 					<Tool Name="VCLinkerTool"
-						AdditionalDependencies="$(SolutionName).lib omniORB4_rt.lib omniDynamic4_rt.lib COS4_rt.lib omniThread_rt.lib tango.lib zmq.lib log4tango.lib comctl32.lib ws2_32.lib"
+						AdditionalDependencies="$(SolutionName).lib omniORB4_rt.lib omniDynamic4_rt.lib COS4_rt.lib omniThread_rt.lib tango.lib zmq.lib comctl32.lib ws2_32.lib"
 						ShowProgress="0"
 						OutputFile="$(OutDir)\$(SolutionName).exe"
 						LinkIncremental="1"
@@ -633,7 +633,7 @@ class VC9_Project {
 					<Tool Name="VCPreLinkEventTool" />
 					<Tool
 						Name="VCLinkerTool"
-						AdditionalDependencies="$(SolutionName)d.lib omniORB4_rtd.lib omniDynamic4_rtd.lib COS4_rtd.lib omnithread_rtd.lib tangod.lib zmqd.lib log4tangod.lib comctl32.lib ws2_32.lib"
+						AdditionalDependencies="$(SolutionName)d.lib omniORB4_rtd.lib omniDynamic4_rtd.lib COS4_rtd.lib omnithread_rtd.lib tangod.lib zmqd.lib comctl32.lib ws2_32.lib"
 						ShowProgress="0"
 						OutputFile="$(OutDir)\$(SolutionName).exe"
 						LinkIncremental="2"


### PR DESCRIPTION
Following kernel decision to merge liblog4tango into libtango in 9.3.3 ([#22], [#30]), I propose to remove references to liblog4tango from templates generated by pogo. The changes are Windows-specific. As for linux, liblog4tango is referenced from pkg-config file in source distribution. There also may be a potential change in cmake_tango.opt file, but I do not know from where this file is located.

CC @bourtemb 

[#22]: https://github.com/tango-controls/TangoSourceDistribution/issues/22
[#30]: https://github.com/tango-controls/TangoSourceDistribution/issues/30