### PR TITLE
remove extra ";" warning (error with old compilers)

### DIFF
--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/Main.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/Main.xtend
@@ -78,7 +78,7 @@ class Main {
 		#  define INSTALL_CRASH_HANDLER
 		#endif
 		
-		DECLARE_CRASH_HANDLER;
+		DECLARE_CRASH_HANDLER
 
 		int main(int argc,char *argv[])
 		{


### PR DESCRIPTION
Removing extra comma after DECLARE_CRASH_HANDLER
Triggers a warning when compiling generated C++ code with recent compilers. Error with old g++ 4.1.3