### PR TITLE
Modifying the Python tests' template to suit the needs of the SKA project

### DIFF
--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PyUtils.java
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PyUtils.java
@@ -134,24 +134,24 @@ public class PyUtils {
 	 * @return  the method execution name for specified command
 	 */
 	//===========================================================
-	String methodTest(Command cmd, String defVal) {
-		if (cmd.getName().equals("State")) {
-			return "self.device.State()";
+	String methodTest(Command command, String defVal) {
+		if (command.getName().equals("State")) {
+			return "tango_context.device.State()";
 		}
 		else
 		{
-			if (cmd.getName().equals("Status")) {
-				return "self.device.Status()";
+			if (command.getName().equals("Status")) {
+				return "tango_context.device.Status()";
 			}
 			else
 			{
-				if (cmd.getArgin().getType().equals("VoidTypeImpl")==false)
+				if (command.getArgin().getType().equals("VoidTypeImpl")==false)
 				{
-					return "self.device." + cmd.getName() + "("+ defVal +")";
+					return "tango_context.device." + command.getName() + "("+ defVal +")";
 				}
 				else
 				{
-					return "self.device." + cmd.getName() + "()";
+					return "tango_context.device." + command.getName() + "()";
 				}
 			}
 		}
@@ -160,15 +160,15 @@ public class PyUtils {
 	//===========================================================
 	/**
 	 * Returns the enum labels on one line 
-	 * @param command the specified command
+	 * @param attribute Attribute
 	 * @return  the method execution name for specified command
 	 */
 	//===========================================================
-    String pythonPipeEnum(Attribute attr){
-    	if (attr.getEnumLabels() != null)
+    String pythonPipeEnum(Attribute attribute) {
+        if (attribute.getEnumLabels() != null)
     	{
 			StringBuilder	sb = new StringBuilder("[");
-			for (String label : attr.getEnumLabels())
+			for (String label : attribute.getEnumLabels())
 			{
 				sb.append("\"").append(label).append("\", ");
 			}

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PythonTypeDefinitions.java
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PythonTypeDefinitions.java
@@ -308,11 +308,11 @@ public class PythonTypeDefinitions {
 		
 		if (attr.getAttType().equals("Spectrum"))
 		{
-			def_val = "[" + def_val + "]";
+			def_val = "(" + def_val + ",)";
 		}
 		if (attr.getAttType().equals("Image"))
 		{
-			def_val = "[[" + def_val + "]]";
+			def_val = "((" + def_val + ",),)";
 		}
 		return def_val;
 	}

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PythonUtils.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PythonUtils.xtend
@@ -39,6 +39,7 @@ import fr.esrf.tango.pogo.pogoDsl.Command
 import fr.esrf.tango.pogo.pogoDsl.Attribute
 import fr.esrf.tango.pogo.pogoDsl.ForwardedAttribute
 import fr.esrf.tango.pogo.pogoDsl.PogoDeviceClass
+import fr.esrf.tango.pogo.pogoDsl.ForwardedAttribute
 import fr.esrf.tango.pogo.pogoDsl.Property
 import fr.esrf.tango.pogo.pogoDsl.Pipe
 import com.google.inject.Inject
@@ -260,7 +261,19 @@ class PythonUtils {
 «IF cmd.hasCommandArg»    )«ENDIF»«ENDIF»«ENDIF»
     @DebugIt()
     def «cmd.methodName»(self«IF !cmd.argin.type.voidType», argin«ENDIF»):
-        «IF cls.description.filestogenerate.toLowerCase.contains("protected regions")»«protectedAreaHL(cls, cmd.name, cmd.argout.type.defaultValueReturnHL, false)»«ELSE»«IF !cmd.argout.type.voidType»return «cmd.argout.type.defaultValueTestHL»«ELSE»pass«ENDIF»«ENDIF»
+        «IF cls.description.filestogenerate.toLowerCase.contains("protected regions")»
+            «IF !cmd.argout.type.voidType»
+                «protectedAreaHL(cls, cmd.name, cmd.argout.type.defaultValueReturnHL, false)»
+            «ELSE»
+                pass
+            «ENDIF»
+        «ELSE»
+            «IF !cmd.argout.type.voidType»
+                return «cmd.argout.type.defaultValueTestHL»
+            «ELSE»
+                pass
+            «ENDIF»
+        «ENDIF»
 
 «ENDIF»
 '''


### PR DESCRIPTION
- **PythonHlProjectUtils.xtend**:
    * Removed unused imports and added the `pytest` import statement.
    * Decorated the test class with `@pytest.mark.usefixtures`, using user-defined fixtures.
    * Added protected regions for decorators.
    * Improved readability.
    * Generating basic tests that check attribute reads and command executions return their expected default initial values, respectively.

- **PyUtils.java**:
    * Changed strings `self.device.*` => `tango_context.device.*`.

- **PythonUtils.xtend**:
    * Changed format to improve code readability.

This work was done in relation to the [SKA LMC base classes](https://github.com/ska-telescope/lmc-base-classes) project.