### PR TITLE
PythonHL code generation issue resolution - Added '_' character in code in order to allow '_' in Enum lables, Added command description in code generator, Modified PyTango import section.

### DIFF
--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PythonDeviceHL.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PythonDeviceHL.xtend
@@ -189,14 +189,14 @@ class «cls.name»(«cls.inheritedPythonClassNameHL»):
 """
 
 # PyTango imports
-import PyTango
-from PyTango import DebugIt
-from PyTango.server import run
-from PyTango.server import Device, DeviceMeta
-«IF !cls.attributes.empty || !cls.commands.empty || !cls.pipes.empty»from PyTango.server import «IF !cls.attributes.empty»attribute«ENDIF»«IF !cls.commands.empty»«IF !cls.attributes.empty», «ENDIF»command«ENDIF»«IF !cls.pipes.empty»«IF !cls.attributes.empty || !cls.commands.empty», «ENDIF»pipe«ENDIF»«ENDIF»
-«IF !cls.classProperties.empty || !cls.deviceProperties.empty»from PyTango.server import «IF !cls.classProperties.empty»class_property, «ENDIF»«IF !cls.deviceProperties.empty»device_property«ENDIF»«ENDIF»
-from PyTango import AttrQuality, DispLevel, DevState
-from PyTango import AttrWriteType, PipeWriteType
+import tango
+from tango import DebugIt
+from tango.server import run
+from tango.server import Device, DeviceMeta
+«IF !cls.attributes.empty || !cls.commands.empty || !cls.pipes.empty»from tango.server import «IF !cls.attributes.empty»attribute«ENDIF»«IF !cls.commands.empty»«IF !cls.attributes.empty», «ENDIF»command«ENDIF»«IF !cls.pipes.empty»«IF !cls.attributes.empty || !cls.commands.empty», «ENDIF»pipe«ENDIF»«ENDIF»
+«IF !cls.classProperties.empty || !cls.deviceProperties.empty»from tango.server import «IF !cls.classProperties.empty»class_property, «ENDIF»«IF !cls.deviceProperties.empty»device_property«ENDIF»«ENDIF»
+from tango import AttrQuality, DispLevel, DevState
+from tango import AttrWriteType, PipeWriteType
 «cls.inheritedAdditionalImportHL»
 # Additional import
 «IF cls.description.filestogenerate.toLowerCase.contains("protected regions")»«cls.protectedAreaHL("additionnal_import")»«ENDIF»

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PythonUtils.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PythonUtils.xtend
@@ -250,14 +250,25 @@ class PythonUtils {
         '''
         
     def commandExecutionHL(PogoDeviceClass cls, Command cmd) '''
-«IF isTrue(cmd.status.concreteHere)»«IF cmd.name != "State"»«IF cmd.name != "Status"»    @command«IF cmd.hasCommandArg»(«ENDIF»
-«IF !cmd.argin.type.voidType»    dtype_in=«cmd.argin.type.pythonTypeHL», 
-«IF !cmd.argin.description.empty»    doc_in="«cmd.argin.description.oneLineString»", «ENDIF»«ENDIF»
-«IF !cmd.argout.type.voidType»    dtype_out=«cmd.argout.type.pythonTypeHL», 
-«IF !cmd.argout.description.empty»    doc_out="«cmd.argout.description.oneLineString»", «ENDIF»«ENDIF»
+«IF isTrue(cmd.status.concreteHere)»
+	«IF cmd.name != "State"»
+		«IF cmd.name != "Status"»    @command«IF cmd.hasCommandArg»(«ENDIF»
+		«IF !cmd.argin.type.voidType»    dtype_in=«cmd.argin.type.pythonTypeHL», 
+		«IF !cmd.argin.description.empty»    doc_in="«cmd.argin.description.oneLineString»", 
+		«ENDIF»
+		«ENDIF»
+		«IF !cmd.argout.type.voidType»    dtype_out=«cmd.argout.type.pythonTypeHL», 
+		«IF !cmd.argout.description.empty»    doc_out="«cmd.argout.description.oneLineString»", 
+		«ENDIF»
+		«ENDIF»
+		«IF !cmd.description.empty»    description="«cmd.description.oneLineString»",
+		«ENDIF»
     «setAttrPropertyHL("display_level", cmd.displayLevel, false)»
     «setAttrPropertyHL("polling_period", cmd.polledPeriod, false)»
-«IF cmd.hasCommandArg»    )«ENDIF»«ENDIF»«ENDIF»
+		«IF cmd.hasCommandArg»    )
+		«ENDIF»
+	«ENDIF»
+«ENDIF»
     @DebugIt()
     def «cmd.methodName»(self«IF !cmd.argin.type.voidType», argin«ENDIF»):
         «IF cls.description.filestogenerate.toLowerCase.contains("protected regions")»«protectedAreaHL(cls, cmd.name, cmd.argout.type.defaultValueReturnHL, false)»«ELSE»«IF !cmd.argout.type.voidType»return «cmd.argout.type.defaultValueTestHL»«ELSE»pass«ENDIF»«ENDIF»

--- a/org.tango.pogo.pogo_gui/src/org/tango/pogo/pogo_gui/EnumDialog.java
+++ b/org.tango.pogo.pogo_gui/src/org/tango/pogo/pogo_gui/EnumDialog.java
@@ -231,7 +231,7 @@ public class EnumDialog extends JDialog {
 
     //===============================================================
     //===============================================================
-    private static final char[] authorizedChars = { ' ', '*', '/', '+', '-', '.', '=', '%', '>', '<' };
+    private static final char[] authorizedChars = { ' ', '*', '/', '+', '-', '.', '=', '%', '>', '<','_' };
     private boolean isAuthorized(char c) {
         for (char c1 : authorizedChars) {
             if (c1==c)


### PR DESCRIPTION
1. Enum labels used in SKA TANGO devices use the underscore character. This update is done to resolve this issue. Added '_' character in autorizedChars list in EnumDialog.java code. 
2. Added Command Description as part of command in CommandExecutionHL method. This update is done to generate command description provided in command section of PythonHL code.
3. Updated #PyTango import section. Imports updated from PyTango to tango as the latest version of tango needs tango import instead of PyTango import. 