### PR TITLE
License Addition - BSD 3 

### DIFF
--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/common/ILicences.java
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/common/ILicences.java
@@ -45,7 +45,8 @@ interface ILicences {
     static final int LGPL   = 1;
     static final int APACHE = 2;
     static final int MIT    = 3;
-    static final int NONE   = 4;
+    static final int BSD3   = 4;
+    static final int NONE   = 5;
 /*
 	static String licenseText(String licence, String commentTag) {
 		if (licence!=null && licence.equals("none"))
@@ -64,6 +65,12 @@ interface ILicences {
 					"\n"+
 					"Tango is free software: you can redistribute it and/or modify\n" +
 					"it under the terms of the MIT licence.\n";
+    
+    static final String	bsdLicenece =
+					"This file is part of Tango device class.\n" +
+					"\n"+
+					"Tango is free software: you can redistribute it and/or modify\n" +
+					"it under the terms of the BSD-3 Clause licence.\n";
 
     static final String	gplLicenece =
 					"This file is part of Tango device class.\n" +

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/common/StringUtils.java
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/common/StringUtils.java
@@ -480,6 +480,9 @@ public class StringUtils {
 		if (licence!=null && licence.equals("MIT"))
 			return commentTag + comments(ILicences.mitLicenece, commentTag) + "\n";
 
+		if (licence!=null && licence.equals("BSD3"))
+			return commentTag + comments(ILicences.bsdLicenece, commentTag) + "\n";
+		
 		//	default IS GPL
 		if (licence!=null && licence.equals("LGPL")) {
 			// convert gpl to lgpl

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PythonDeviceHL.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PythonDeviceHL.xtend
@@ -73,6 +73,9 @@ class PythonDeviceHL implements IGenerator {
 				else if (cls.description.license == 'MIT') {
 					fsa.generateFile("LICENSE.txt",  cls.generatePythonHlProjectLicenseMIT)
 				}
+				else if (cls.description.license == 'BSD3') {
+					fsa.generateFile("LICENSE.txt",  cls.generatePythonHlProjectLicenseBSD)
+				}
 				if (cls.description.filestogenerate.toLowerCase.contains('sphinx')){
 					fsa.generateFile("docs/source/index.rst",cls.generatePythonHlSphinxIndex)
 					fsa.generateFile("docs/source/conf.py",cls.generatePythonHlSphinxConf)
@@ -239,7 +242,6 @@ __all__ = ["«cls.name»", "main"]
         pass
         «ENDIF»
 «ENDIF»
-
 '''
 
     //====================================================

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PythonHlProjectUtils.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PythonHlProjectUtils.xtend
@@ -662,6 +662,42 @@ THE SOFTWARE.
 	//======================================================
 	// Define PythonHl project license code to be generated
 	//======================================================
+	def generatePythonHlProjectLicenseBSD(PogoDeviceClass cls) '''
+The BSD 3-Clause License
+
+Copyright (c) «IF cls.description.copyright.isSet»«cls.description.copyright.oneLineString»«ELSE»<YEAR> <COPYRIGHT HOLDER>«ENDIF»
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+	'''
+
+
+	//======================================================
+	// Define PythonHl project license code to be generated
+	//======================================================
 	def generatePythonHlProjectLicenseAPACHE(PogoDeviceClass cls) '''
                                  Apache License
                            Version 2.0, January 2004

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PythonHlProjectUtils.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PythonHlProjectUtils.xtend
@@ -638,7 +638,7 @@ If the Library as you received it specifies that a proxy can decide whether futu
 	def generatePythonHlProjectLicenseMIT(PogoDeviceClass cls) '''
 	The MIT License
 
-Copyright (c) 2006-2010 Stephen M. McKamey
+Copyright (c) «IF cls.description.copyright.isSet»«cls.description.copyright.oneLineString»«ELSE»<YEAR> <COPYRIGHT HOLDER>«ENDIF»
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -887,7 +887,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright «IF cls.description.copyright.isSet»«cls.description.copyright.oneLineString»«ELSE»[yyyy] [name of copyright owner]«ENDIF»
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PythonUtils.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PythonUtils.xtend
@@ -262,8 +262,8 @@ class PythonUtils {
 		«IF !cmd.argout.description.empty»        doc_out="«cmd.argout.description.oneLineString»",
 		«ENDIF»
 		«ENDIF»
-    «setAttrPropertyHL("display_level", cmd.displayLevel, false)»
-    «setAttrPropertyHL("polling_period", cmd.polledPeriod, false)»
+        «setAttrPropertyHL("display_level", cmd.displayLevel, false)»
+        «setAttrPropertyHL("polling_period", cmd.polledPeriod, false)»
 		«IF cmd.hasCommandArg»    )
 		«ENDIF»
 		«ENDIF»

--- a/org.tango.pogo.pogo_gui/src/org/tango/pogo/pogo_gui/ClassDialog.java
+++ b/org.tango.pogo.pogo_gui/src/org/tango/pogo/pogo_gui/ClassDialog.java
@@ -102,6 +102,7 @@ public class ClassDialog extends JDialog {
         licenseComboBox.addItem("LGPL");
         licenseComboBox.addItem("APACHE");
         licenseComboBox.addItem("MIT");
+        licenseComboBox.addItem("BSD3");
         licenseComboBox.addItem("none");
 
         if (deviceClass == null) {  //  Creating a new class


### PR DESCRIPTION
Added License BSD 3 in POGO code generator.
1. Added BSD 3 in the list of items in a license drop down box.
2. Added description for the BSD 3 license in CPP, Java, Python code generation.
3. Updated License file generation in PythonHL code generation.