### PR TITLE
Allows to override MAKE_ENV without modification of Makefile.

### DIFF
--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/projects/MakefileUtils.java
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/projects/MakefileUtils.java
@@ -387,7 +387,7 @@ public class MakefileUtils extends fr.esrf.tango.pogo.generator.common.StringUti
 		if (cmake)
 			code += "set(MAKE_ENV ";
 		else
-			code += "MAKE_ENV = ";
+			code += "MAKE_ENV ?= ";
 
 		if (dbg!=null) //	To force it under development
 			code += dbg;
@@ -410,7 +410,7 @@ public class MakefileUtils extends fr.esrf.tango.pogo.generator.common.StringUti
 		if (cmake)
 			code += "set(MAKE_ENV ";
 		else
-			code += "MAKE_ENV = ";
+			code += "MAKE_ENV ?= ";
 
 		if (dbg!=null) //	To force it under development
 			code += dbg;


### PR DESCRIPTION
It is useful in cases when it is necessary to modify building steps or flags (e.g cross compilation, packaging, custom location of tango/zmq/omni etc.).
