### PR TITLE
Generated variables corresponding to attributes in PythonHL.

### DIFF
--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PythonDeviceHL.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PythonDeviceHL.xtend
@@ -264,6 +264,11 @@ def enumClasses(PogoDeviceClass cls) '''
         «cls.setEventCriteria»
         «IF cls.description.filestogenerate.toLowerCase.contains("protected regions")»
         «cls.openProtectedAreaHL("init_device")»
+        «IF !cls.attributes.empty»
+        «FOR attr:cls.attributes»
+        self._«attr.pythonAttributeVariableNameHL» = «attr.defaultValueHL»
+        «ENDFOR»
+        «ENDIF»
         «cls.closeProtectedAreaHL("init_device")»
         «ENDIF»
 

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PythonTypeDefinitions.java
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PythonTypeDefinitions.java
@@ -317,7 +317,10 @@ public class PythonTypeDefinitions {
 		if (attr.getDataType() instanceof ULongType)			def_val =  "0";
 		if (attr.getDataType() instanceof DevIntType)			def_val =  "0";
 		if (attr.getDataType() instanceof EncodedType)			def_val =  "['', '']";
-		if (attr.getDataType() instanceof EnumType)			def_val =  "0";
+		if (attr.getDataType() instanceof EnumType)
+		{
+			def_val = toFirstUpper(attr.getName())+ "."+ attr.getEnumLabels().get(0);
+		}
 		
 		if (attr.getAttType().equals("Spectrum"))
 		{

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PythonUtils.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PythonUtils.xtend
@@ -658,8 +658,8 @@ class PythonUtils {
 	    			count+=1
 	    		}
     		}
-    	} 
-		return attrVariableName.toLowerCase
+    	}
+    	return attrVariableName.toLowerCase
 	}
 
     

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PythonUtils.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PythonUtils.xtend
@@ -45,6 +45,7 @@ import fr.esrf.tango.pogo.pogoDsl.Pipe
 import com.google.inject.Inject
 import static extension fr.esrf.tango.pogo.generator.python.PythonTypeDefinitions.*
 import static extension fr.esrf.tango.pogo.generator.common.StringUtils.*
+import org.eclipse.emf.common.util.BasicEList
 
 class PythonUtils {
     @Inject extension fr.esrf.tango.pogo.generator.common.StringUtils
@@ -429,7 +430,7 @@ class PythonUtils {
                 «IF cls.description.filestogenerate.toLowerCase.contains("protected regions")»
                 «openProtectedAreaHL(cls, attribute.name + "_read")»
                 """Return the «attribute.name» attribute."""
-                return «attribute.defaultValueHL»
+                return self._«attribute.pythonAttributeVariableNameHL»
                 «closeProtectedAreaHL(cls, attribute.name + "_read")»
                 «ELSE»
                 return «attribute.defaultValueDim»
@@ -625,6 +626,42 @@ class PythonUtils {
         else
             return "";
     }
+    
+    def String pythonAttributeVariableNameHL(Attribute attr) {
+    	var attrVariableName = attr.name
+    	var indexList = new BasicEList<Integer>
+    	var ch =0 
+    	var stringSize = (attr.name.length -1)
+    	for (ch =0; ch < attrVariableName.length; ch++){
+    		if(Character.isUpperCase(attrVariableName.charAt(ch))){
+    			indexList.add(ch);
+    		}
+    	}
+    	var checkNxtIndex = 0
+    	var position = 0
+    	var count = 0
+    	for (index:indexList){
+    		if(checkNxtIndex !== stringSize)
+    		{   			
+	    		if(index==checkNxtIndex){
+	    			checkNxtIndex = (index +1)
+	    			if(Character.isLowerCase(attr.name.charAt((checkNxtIndex)))){
+	    				position = (index + count)
+	    				attrVariableName = attrVariableName.substring(0, position)+ '_' + attrVariableName.substring(position)
+	    				count+=1
+	    			}
+	    		}
+	    		else{
+	    			position = (index + count)
+	    			attrVariableName = attrVariableName.substring(0, position)+ '_' + attrVariableName.substring(position)
+	    			checkNxtIndex = (index +1)
+	    			count+=1
+	    		}
+    		}
+    	} 
+		return attrVariableName.toLowerCase
+	}
+
     
     def pythonAttributeClass(Attribute attr) '''        '«attr.name»':
             [[«attr.dataType.pythonType»,


### PR DESCRIPTION
 Variables corresponding to device attributes are generated in init_device method of PythonHL code. Also, the return statement in read attribute methods is updated with variable names. 
Attached the zip file of code before changes and after changes. 
[CheckVariableName-After.zip](https://github.com/tango-controls/pogo/files/4133939/CheckVariableName-After.zip)
[AttributeGenerationBefore.zip](https://github.com/tango-controls/pogo/files/4133941/AttributeGenerationBefore.zip)

