### PR TITLE
Add polling for State and Status command in PythonHL

### DIFF
--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PythonDeviceHL.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PythonDeviceHL.xtend
@@ -264,6 +264,16 @@ def enumClasses(PogoDeviceClass cls) '''
         «cls.setEventCriteria»
         «IF cls.description.filestogenerate.toLowerCase.contains("protected regions")»
         «cls.openProtectedAreaHL("init_device")»
+        «IF !cls.commands.empty»
+        «FOR cmd:cls.commands»
+        «IF cmd.name == "State" && cmd.polledPeriod.integerValue !== 0»
+        self.poll_command('State', «cmd.polledPeriod»)
+        «ENDIF»
+        «IF cmd.name == 'Status' && cmd.polledPeriod.integerValue !== 0»
+        self.poll_command('Status', «cmd.polledPeriod»)
+        «ENDIF»
+        «ENDFOR»
+        «ENDIF»
         «IF !cls.attributes.empty»
         «FOR attr:cls.attributes»
         self._«attr.pythonAttributeVariableNameHL» = «attr.defaultValueHL»


### PR DESCRIPTION
Added polling for State and Status command in PythonHL. 

This partly addresses issue #53 (code generated for the old "low level" Python was not updated in this PR)

Attached the generated code before and after implementation.
[stateCommandPollingAfter.zip](https://github.com/tango-controls/pogo/files/4153283/stateCommandPollingAfter.zip)
[stateCommandPollingBefore.zip](https://github.com/tango-controls/pogo/files/4153284/stateCommandPollingBefore.zip)

For reviewers, the only meaningful difference in the content of those two zip files is this:
```
git diff pogo-91-stateCommandPollingBefore/ pogo-91-stateCommandPollingAfter/
...
diff --git a/pogo-91-stateCommandPollingBefore/StateCommandPolling/StateCommandPolling.py b/pogo-91-stateCommandPollingAfter/StateCommandPolling/StateCommandPolling.py
index a471218..69d6e0a 100644
--- a/pogo-91-stateCommandPollingBefore/StateCommandPolling/StateCommandPolling.py
+++ b/pogo-91-stateCommandPollingAfter/StateCommandPolling/StateCommandPolling.py
@@ -41,6 +41,8 @@ class StateCommandPolling(Device):
         """Initialises the attributes and properties of the StateCommandPolling."""
         Device.init_device(self)
         # PROTECTED REGION ID(StateCommandPolling.init_device) ENABLED START #
+        self.poll_command('State', 3000)
+        self.poll_command('Status', 1300)
         # PROTECTED REGION END #    //  StateCommandPolling.init_device
 
     def always_executed_hook(self):
...
```