### PR TITLE
Add std prefix

### DIFF
--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/DeviceClassInclude.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/DeviceClassInclude.xtend
@@ -224,9 +224,9 @@ class DeviceClassInclude {
 			static «cls.name»Class *init(const char *);
 			static «cls.name»Class *instance();
 			~«cls.name»Class();
-			Tango::DbDatum	get_class_property(string &);
-			Tango::DbDatum	get_default_device_property(string &);
-			Tango::DbDatum	get_default_class_property(string &);
+			Tango::DbDatum	get_class_property(std::string &);
+			Tango::DbDatum	get_default_device_property(std::string &);
+			Tango::DbDatum	get_default_class_property(std::string &);
 		
 	'''
 	
@@ -235,7 +235,7 @@ class DeviceClassInclude {
 	//======================================================
 	def protectedMethodPrototypes(PogoDeviceClass cls) '''
 		protected:
-			«cls.name»Class(string &);
+			«cls.name»Class(std::string &);
 			static «cls.name»Class *_instance;
 			void command_factory();
 			void attribute_factory(std::vector<Tango::Attr *> &);
@@ -243,8 +243,8 @@ class DeviceClassInclude {
 			void write_class_property();
 			void set_default_property();
 			void get_class_property();
-			string get_cvstag();
-			string get_cvsroot();
+			std::string get_cvstag();
+			std::string get_cvsroot();
 		
 	'''
 	
@@ -257,8 +257,8 @@ class DeviceClassInclude {
 			«IF cls.concreteClass»
 				void create_static_attribute_list(std::vector<Tango::Attr *> &);
 				void erase_dynamic_attributes(const Tango::DevVarStringArray *,std::vector<Tango::Attr *> &);
-				std::vector<string>	defaultAttList;
-				Tango::Attr *get_attr_object_by_name(std::vector<Tango::Attr *> &att_list, string attname);
+				std::vector<std::string>	defaultAttList;
+				Tango::Attr *get_attr_object_by_name(std::vector<Tango::Attr *> &att_list, std::string attname);
 			«ENDIF»
 	'''
 }

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/DeviceClassInclude.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/DeviceClassInclude.xtend
@@ -238,7 +238,7 @@ class DeviceClassInclude {
 			«cls.name»Class(string &);
 			static «cls.name»Class *_instance;
 			void command_factory();
-			void attribute_factory(vector<Tango::Attr *> &);
+			void attribute_factory(std::vector<Tango::Attr *> &);
 			void pipe_factory();
 			void write_class_property();
 			void set_default_property();
@@ -255,10 +255,10 @@ class DeviceClassInclude {
 		private:
 			void device_factory(const Tango::DevVarStringArray *);
 			«IF cls.concreteClass»
-				void create_static_attribute_list(vector<Tango::Attr *> &);
-				void erase_dynamic_attributes(const Tango::DevVarStringArray *,vector<Tango::Attr *> &);
-				vector<string>	defaultAttList;
-				Tango::Attr *get_attr_object_by_name(vector<Tango::Attr *> &att_list, string attname);
+				void create_static_attribute_list(std::vector<Tango::Attr *> &);
+				void erase_dynamic_attributes(const Tango::DevVarStringArray *,std::vector<Tango::Attr *> &);
+				std::vector<string>	defaultAttList;
+				Tango::Attr *get_attr_object_by_name(std::vector<Tango::Attr *> &att_list, string attname);
 			«ENDIF»
 	'''
 }

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/DeviceClassSource.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/DeviceClassSource.xtend
@@ -171,7 +171,7 @@ class DeviceClassSource {
 	//==========================================================
 	def attributeFactory(PogoDeviceClass cls) '''
 		«cls.simpleMethodHeaderClass("attribute_factory", "Create the attribute object(s)\nand store them in the attribute list")»
-		void «cls.name»Class::attribute_factory(vector<Tango::Attr *> &att_list)
+		void «cls.name»Class::attribute_factory(std::vector<Tango::Attr *> &att_list)
 		{
 			«cls.protectedAreaClass("attribute_factory_before", "Add your own code", true)»
 			«IF cls.hasInheritanceClass»
@@ -327,7 +327,7 @@ class DeviceClassSource {
 			 * @param	att_list	the ceated attribute list
 			 */
 			//--------------------------------------------------------
-			void «cls.name»Class::create_static_attribute_list(vector<Tango::Attr *> &att_list)
+			void «cls.name»Class::create_static_attribute_list(std::vector<Tango::Attr *> &att_list)
 			{
 				for (unsigned long i=0 ; i<att_list.size() ; i++)
 				{
@@ -351,7 +351,7 @@ class DeviceClassSource {
 			 * @param	list of all attributes
 			 */
 			//--------------------------------------------------------
-			void «cls.name»Class::erase_dynamic_attributes(const Tango::DevVarStringArray *devlist_ptr, vector<Tango::Attr *> &att_list)
+			void «cls.name»Class::erase_dynamic_attributes(const Tango::DevVarStringArray *devlist_ptr, std::vector<Tango::Attr *> &att_list)
 			{
 				Tango::Util *tg = Tango::Util::instance();
 			
@@ -360,14 +360,14 @@ class DeviceClassSource {
 					Tango::DeviceImpl *dev_impl = tg->get_device_by_name(((string)(*devlist_ptr)[i]).c_str());
 					«cls.name» *dev = static_cast<«cls.name» *> (dev_impl);
 			
-					vector<Tango::Attribute *> &dev_att_list = dev->get_device_attr()->get_attribute_list();
-					vector<Tango::Attribute *>::iterator ite_att;
+					std::vector<Tango::Attribute *> &dev_att_list = dev->get_device_attr()->get_attribute_list();
+					std::vector<Tango::Attribute *>::iterator ite_att;
 					for (ite_att=dev_att_list.begin() ; ite_att != dev_att_list.end() ; ++ite_att)
 					{
 						string att_name((*ite_att)->get_name_lower());
 						if ((att_name == "state") || (att_name == "status"))
 							continue;
-						vector<string>::iterator ite_str = find(defaultAttList.begin(), defaultAttList.end(), att_name);
+						std::vector<string>::iterator ite_str = find(defaultAttList.begin(), defaultAttList.end(), att_name);
 						if (ite_str == defaultAttList.end())
 						{
 							cout2 << att_name << " is a UNWANTED dynamic attribute for device " << (*devlist_ptr)[i] << std::endl;
@@ -381,9 +381,9 @@ class DeviceClassSource {
 			}
 
 			«cls.simpleMethodHeaderClass("get_attr_object_by_name", "returns Tango::Attr * object found by name")»
-			Tango::Attr *«cls.name»Class::get_attr_object_by_name(vector<Tango::Attr *> &att_list, string attname)
+			Tango::Attr *«cls.name»Class::get_attr_object_by_name(std::vector<Tango::Attr *> &att_list, string attname)
 			{
-				vector<Tango::Attr *>::iterator it;
+				std::vector<Tango::Attr *>::iterator it;
 				for (it=att_list.begin() ; it<att_list.end() ; ++it)
 					if ((*it)->get_name()==attname)
 						return (*it);

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/DeviceClassSource.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/DeviceClassSource.xtend
@@ -477,7 +477,7 @@ class DeviceClassSource {
 		{
 			if (_instance == NULL)
 			{
-				cerr << "Class is not initialised !!" << std::endl;
+				std::cerr << "Class is not initialised !!" << std::endl;
 				exit(-1);
 			}
 			return _instance;

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/DeviceClassSource.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/DeviceClassSource.xtend
@@ -458,7 +458,7 @@ class DeviceClassSource {
 					string s(name);
 					_instance = new «cls.name»Class(s);
 				}
-				catch (bad_alloc &)
+				catch (std::bad_alloc &)
 				{
 					throw;
 				}

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/DeviceClassSource.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/DeviceClassSource.xtend
@@ -331,7 +331,7 @@ class DeviceClassSource {
 			{
 				for (unsigned long i=0 ; i<att_list.size() ; i++)
 				{
-					string att_name(att_list[i]->get_name());
+					std::string att_name(att_list[i]->get_name());
 					transform(att_name.begin(), att_name.end(), att_name.begin(), ::tolower);
 					defaultAttList.push_back(att_name);
 				}
@@ -357,17 +357,17 @@ class DeviceClassSource {
 			
 				for (unsigned long i=0 ; i<devlist_ptr->length() ; i++)
 				{
-					Tango::DeviceImpl *dev_impl = tg->get_device_by_name(((string)(*devlist_ptr)[i]).c_str());
+					Tango::DeviceImpl *dev_impl = tg->get_device_by_name(((std::string)(*devlist_ptr)[i]).c_str());
 					«cls.name» *dev = static_cast<«cls.name» *> (dev_impl);
 			
 					std::vector<Tango::Attribute *> &dev_att_list = dev->get_device_attr()->get_attribute_list();
 					std::vector<Tango::Attribute *>::iterator ite_att;
 					for (ite_att=dev_att_list.begin() ; ite_att != dev_att_list.end() ; ++ite_att)
 					{
-						string att_name((*ite_att)->get_name_lower());
+						std::string att_name((*ite_att)->get_name_lower());
 						if ((att_name == "state") || (att_name == "status"))
 							continue;
-						std::vector<string>::iterator ite_str = find(defaultAttList.begin(), defaultAttList.end(), att_name);
+						std::vector<std::string>::iterator ite_str = find(defaultAttList.begin(), defaultAttList.end(), att_name);
 						if (ite_str == defaultAttList.end())
 						{
 							cout2 << att_name << " is a UNWANTED dynamic attribute for device " << (*devlist_ptr)[i] << std::endl;
@@ -381,7 +381,7 @@ class DeviceClassSource {
 			}
 
 			«cls.simpleMethodHeaderClass("get_attr_object_by_name", "returns Tango::Attr * object found by name")»
-			Tango::Attr *«cls.name»Class::get_attr_object_by_name(std::vector<Tango::Attr *> &att_list, string attname)
+			Tango::Attr *«cls.name»Class::get_attr_object_by_name(std::vector<Tango::Attr *> &att_list, std::string attname)
 			{
 				std::vector<Tango::Attr *>::iterator it;
 				for (it=att_list.begin() ; it<att_list.end() ; ++it)
@@ -406,13 +406,13 @@ class DeviceClassSource {
 		
 		//--------------------------------------------------------
 		/**
-		 * method : 		«cls.name»Class::«cls.name»Class(string &s)
+		 * method : 		«cls.name»Class::«cls.name»Class(std::string &s)
 		 * description : 	constructor for the «cls.name»Class
 		 *
 		 * @param s	The class name
 		 */
 		//--------------------------------------------------------
-		«cls.name»Class::«cls.name»Class(string &s):«cls.inheritedClassNameForDeviceClass»(s)
+		«cls.name»Class::«cls.name»Class(std::string &s):«cls.inheritedClassNameForDeviceClass»(s)
 		{
 			cout2 << "Entering «cls.name»Class constructor" << std::endl;
 			set_default_property();
@@ -455,7 +455,7 @@ class DeviceClassSource {
 			{
 				try
 				{
-					string s(name);
+					std::string s(name);
 					_instance = new «cls.name»Class(s);
 				}
 				catch (std::bad_alloc &)

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/DeviceClassSource.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/DeviceClassSource.xtend
@@ -275,7 +275,7 @@ class DeviceClassSource {
 				//	Create devices and add it into the device list
 				for (unsigned long i=0 ; i<devlist_ptr->length() ; i++)
 				{
-					cout4 << "Device name : " << (*devlist_ptr)[i].in() << endl;
+					cout4 << "Device name : " << (*devlist_ptr)[i].in() << std::endl;
 					device_list.push_back(new «cls.name»(this, (*devlist_ptr)[i]));
 				}
 			
@@ -336,7 +336,7 @@ class DeviceClassSource {
 					defaultAttList.push_back(att_name);
 				}
 			
-				cout2 << defaultAttList.size() << " attributes in default list" << endl;
+				cout2 << defaultAttList.size() << " attributes in default list" << std::endl;
 			
 				«cls.protectedAreaClass("create_static_att_list")»
 			}
@@ -370,7 +370,7 @@ class DeviceClassSource {
 						vector<string>::iterator ite_str = find(defaultAttList.begin(), defaultAttList.end(), att_name);
 						if (ite_str == defaultAttList.end())
 						{
-							cout2 << att_name << " is a UNWANTED dynamic attribute for device " << (*devlist_ptr)[i] << endl;
+							cout2 << att_name << " is a UNWANTED dynamic attribute for device " << (*devlist_ptr)[i] << std::endl;
 							Tango::Attribute &att = dev->get_device_attr()->get_attr_by_name(att_name.c_str());
 							dev->remove_attribute(att_list[att.get_attr_idx()], true, false);
 							--ite_att;
@@ -414,7 +414,7 @@ class DeviceClassSource {
 		//--------------------------------------------------------
 		«cls.name»Class::«cls.name»Class(string &s):«cls.inheritedClassNameForDeviceClass»(s)
 		{
-			cout2 << "Entering «cls.name»Class constructor" << endl;
+			cout2 << "Entering «cls.name»Class constructor" << std::endl;
 			set_default_property();
 			«IF cls.classProperties.size>0»
 				get_class_property();
@@ -423,7 +423,7 @@ class DeviceClassSource {
 		
 			«cls.protectedAreaClass("constructor")»
 		
-			cout2 << "Leaving «cls.name»Class constructor" << endl;
+			cout2 << "Leaving «cls.name»Class constructor" << std::endl;
 		}
 
 		//--------------------------------------------------------
@@ -477,7 +477,7 @@ class DeviceClassSource {
 		{
 			if (_instance == NULL)
 			{
-				cerr << "Class is not initialised !!" << endl;
+				cerr << "Class is not initialised !!" << std::endl;
 				exit(-1);
 			}
 			return _instance;

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/DeviceInclude.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/DeviceInclude.xtend
@@ -168,7 +168,7 @@ class DeviceInclude  {
 			 *	@param cl	Class.
 			 *	@param s 	Device Name
 			 */
-			«cls.name»(Tango::DeviceClass *cl,string &s);
+			«cls.name»(Tango::DeviceClass *cl,std::string &s);
 			/**
 			 * Constructs a newly device object.
 			 *
@@ -272,11 +272,11 @@ class DeviceInclude  {
 				virtual bool is_«attr.name»_allowed(Tango::AttReqType type);
 				«cls.addDynamicAttributeSignature(attr, true)»
 				«cls.removeDynamicAttributeSignature(attr, true)»
-				«attr.dataType.cppType» *get_«attr.name»_data_ptr(string &name);
+				«attr.dataType.cppType» *get_«attr.name»_data_ptr(std::string &name);
 				«IF attr.isScalar»
-					map<string,«attr.dataType.cppType»>	   «attr.name»_data;
+					map<std::string,«attr.dataType.cppType»>	   «attr.name»_data;
 				«ELSE»
-					map<string,«attr.dataType.cppType» *>	   «attr.name»_data;
+					map<std::string,«attr.dataType.cppType» *>	   «attr.name»_data;
 				«ENDIF»
 			«ENDFOR»
 		«ENDIF»

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/DeviceInclude.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/DeviceInclude.xtend
@@ -236,10 +236,10 @@ class DeviceInclude  {
 		//	Attribute methods
 		public:
 			«cls.simpleMethodHeader1("read_attr_hardware", "Hardware acquisition for attributes.")»
-			virtual void read_attr_hardware(vector<long> &attr_list);
+			virtual void read_attr_hardware(std::vector<long> &attr_list);
 			«IF cls.hasWritableAttribute»
 				«cls.simpleMethodHeader1("write_attr_hardware", "Hardware writing for attributes.")»
-				virtual void write_attr_hardware(vector<long> &attr_list);
+				virtual void write_attr_hardware(std::vector<long> &attr_list);
 			«ENDIF»
 		«IF cls.attributes.size()>0»
 

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/DeviceSource.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/DeviceSource.xtend
@@ -133,7 +133,7 @@ class DeviceSource {
 			 "will be called at device destruction or at init command")»
 		void «cls.name»::delete_device()
 		{
-			DEBUG_STREAM << "«cls.name»::delete_device() " << device_name << endl;
+			DEBUG_STREAM << "«cls.name»::delete_device() " << device_name << std::endl;
 			«cls.protectedArea("delete_device", "Delete device allocated objects", true)»
 			«cls.attributes.deleteAttributeDataMembers»
 			«IF cls.hasInheritanceClass»
@@ -157,7 +157,7 @@ class DeviceSource {
 		«cls.simpleMethodHeader("init_device", "will be called at device initialization.")»
 		void «cls.name»::init_device()
 		{
-			DEBUG_STREAM << "«cls.name»::init_device() create device " << device_name << endl;
+			DEBUG_STREAM << "«cls.name»::init_device() create device " << device_name << std::endl;
 			«cls.protectedArea("init_device_before", "Initialization before get_device_property() call", true)»
 			
 			«IF cls.hasInheritanceClass»
@@ -201,7 +201,7 @@ class DeviceSource {
 					if (class_prop.is_empty() && dev_prop.is_empty())
 					{
 						TangoSys_OMemStream	tms;
-						tms << endl <<"Property \'" << dev_prop.name;
+						tms << std::endl <<"Property \'" << dev_prop.name;
 						if (Tango::Util::instance()->_UseDb==true)
 							tms << "\' is mandatory but not defined in database";
 						else
@@ -209,7 +209,7 @@ class DeviceSource {
 						append_status(tms.str());
 						mandatoryNotDefined = true;
 						«cls.protectedArea("check_mandatory_property",
-							"cerr << tms.str() << \" for \" << device_name << endl;", false)»
+							"cerr << tms.str() << \" for \" << device_name << std::endl;", false)»
 					}
 				}
 
@@ -219,7 +219,7 @@ class DeviceSource {
 		«cls.simpleMethodHeader("always_executed_hook", "method always executed before any command is executed")»
 		void «cls.name»::always_executed_hook()
 		{
-			DEBUG_STREAM << "«cls.name»::always_executed_hook()  " << device_name << endl;
+			DEBUG_STREAM << "«cls.name»::always_executed_hook()  " << device_name << std::endl;
 			«IF cls.deviceProperties.hasMandatoryProperty»
 				if (mandatoryNotDefined)
 				{
@@ -255,14 +255,14 @@ class DeviceSource {
 		«cls.simpleMethodHeader("read_attr_hardware", "Hardware acquisition for attributes")»
 		void «cls.name»::read_attr_hardware(TANGO_UNUSED(vector<long> &attr_list))
 		{
-			DEBUG_STREAM << "«cls.name»::read_attr_hardware(vector<long> &attr_list) entering... " << endl;
+			DEBUG_STREAM << "«cls.name»::read_attr_hardware(vector<long> &attr_list) entering... " << std::endl;
 			«cls.protectedArea("read_attr_hardware", "Add your own code", true)»
 		}
 		«IF cls.hasWritableAttribute»
 		«cls.simpleMethodHeader("write_attr_hardware", "Hardware writing for attributes")»
 		void «cls.name»::write_attr_hardware(TANGO_UNUSED(vector<long> &attr_list))
 		{
-			DEBUG_STREAM << "«cls.name»::write_attr_hardware(vector<long> &attr_list) entering... " << endl;
+			DEBUG_STREAM << "«cls.name»::write_attr_hardware(vector<long> &attr_list) entering... " << std::endl;
 			«cls.protectedArea("write_attr_hardware", "Add your own code", true)»
 		}
 		«ENDIF»

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/DeviceSource.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/DeviceSource.xtend
@@ -111,7 +111,7 @@ class DeviceSource {
 		
 		«cls.simpleMethodHeader(cls.name,
 			 "Constructors for a Tango device\nimplementing the class" + cls.name)»
-		«cls.name»::«cls.name»(Tango::DeviceClass *cl, string &s)
+		«cls.name»::«cls.name»(Tango::DeviceClass *cl, std::string &s)
 		 : «cls.inheritedClassName»(cl, s.c_str())
 		{
 			«cls.protectedArea("constructor_1", "init_device();", false)»

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/DeviceSource.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/DeviceSource.xtend
@@ -209,7 +209,7 @@ class DeviceSource {
 						append_status(tms.str());
 						mandatoryNotDefined = true;
 						«cls.protectedArea("check_mandatory_property",
-							"cerr << tms.str() << \" for \" << device_name << std::endl;", false)»
+							"std::cerr << tms.str() << \" for \" << device_name << std::endl;", false)»
 					}
 				}
 

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/DeviceSource.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/DeviceSource.xtend
@@ -253,16 +253,16 @@ class DeviceSource {
 	//======================================================
 	def attributeMethods(PogoDeviceClass cls) '''
 		«cls.simpleMethodHeader("read_attr_hardware", "Hardware acquisition for attributes")»
-		void «cls.name»::read_attr_hardware(TANGO_UNUSED(vector<long> &attr_list))
+		void «cls.name»::read_attr_hardware(TANGO_UNUSED(std::vector<long> &attr_list))
 		{
-			DEBUG_STREAM << "«cls.name»::read_attr_hardware(vector<long> &attr_list) entering... " << std::endl;
+			DEBUG_STREAM << "«cls.name»::read_attr_hardware(std::vector<long> &attr_list) entering... " << std::endl;
 			«cls.protectedArea("read_attr_hardware", "Add your own code", true)»
 		}
 		«IF cls.hasWritableAttribute»
 		«cls.simpleMethodHeader("write_attr_hardware", "Hardware writing for attributes")»
-		void «cls.name»::write_attr_hardware(TANGO_UNUSED(vector<long> &attr_list))
+		void «cls.name»::write_attr_hardware(TANGO_UNUSED(std::vector<long> &attr_list))
 		{
-			DEBUG_STREAM << "«cls.name»::write_attr_hardware(vector<long> &attr_list) entering... " << std::endl;
+			DEBUG_STREAM << "«cls.name»::write_attr_hardware(std::vector<long> &attr_list) entering... " << std::endl;
 			«cls.protectedArea("write_attr_hardware", "Add your own code", true)»
 		}
 		«ENDIF»

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/DynamicAttributeUtils.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/DynamicAttributeUtils.xtend
@@ -143,9 +143,9 @@ class DynamicAttributeUtils {
 		{
 			remove_attribute(attname, true, Tango::Util::instance()->_UseDb);
 			«IF attribute.isScalar»
-			    map<string,«attribute.strType»>::iterator ite;
+			    map<std::string,«attribute.strType»>::iterator ite;
 			«ELSE»
-			    map<string,«attribute.strType» *>::iterator ite;
+			    map<std::string,«attribute.strType» *>::iterator ite;
 			«ENDIF»
 		    if ((ite=«attribute.name»_data.find(attname))!=«attribute.name»_data.end())
 		    {
@@ -170,12 +170,12 @@ class DynamicAttributeUtils {
 		 *  parameter attname: the specified attribute name.
 		 */
 		//--------------------------------------------------------
-		«attribute.strType» *«cls.name»::get_«attribute.name»_data_ptr(string &name)
+		«attribute.strType» *«cls.name»::get_«attribute.name»_data_ptr(std::string &name)
 		{
 			«IF attribute.isScalar»
-			    map<string,«attribute.strType»>::iterator ite;
+			    map<std::string,«attribute.strType»>::iterator ite;
 			«ELSE»
-			    map<string,«attribute.strType» *>::iterator ite;
+			    map<std::string,«attribute.strType» *>::iterator ite;
 			«ENDIF»
 		    if ((ite=«attribute.name»_data.find(name))==«attribute.name»_data.end())
 		    {

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/Main.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/Main.xtend
@@ -96,20 +96,20 @@ class Main {
 		
 				// Run the endless loop
 				//----------------------------------------
-				cout << "Ready to accept request" << std::endl;
+				std::cout << "Ready to accept request" << std::endl;
 				tg->server_run();
 			}
 			catch (std::bad_alloc &)
 			{
-				cout << "Can't allocate memory to store device object !!!" << std::endl;
-				cout << "Exiting" << std::endl;
+				std::cout << "Can't allocate memory to store device object !!!" << std::endl;
+				std::cout << "Exiting" << std::endl;
 			}
 			catch (CORBA::Exception &e)
 			{
 				Tango::Except::print_exception(e);
 				
-				cout << "Received a CORBA_Exception" << std::endl;
-				cout << "Exiting" << std::endl;
+				std::cout << "Received a CORBA_Exception" << std::endl;
+				std::cout << "Exiting" << std::endl;
 			}
 			Tango::Util::instance()->server_cleanup();
 			return(0);

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/Main.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/Main.xtend
@@ -99,7 +99,7 @@ class Main {
 				cout << "Ready to accept request" << std::endl;
 				tg->server_run();
 			}
-			catch (bad_alloc &)
+			catch (std::bad_alloc &)
 			{
 				cout << "Can't allocate memory to store device object !!!" << std::endl;
 				cout << "Exiting" << std::endl;

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/Main.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/Main.xtend
@@ -96,20 +96,20 @@ class Main {
 		
 				// Run the endless loop
 				//----------------------------------------
-				cout << "Ready to accept request" << endl;
+				cout << "Ready to accept request" << std::endl;
 				tg->server_run();
 			}
 			catch (bad_alloc &)
 			{
-				cout << "Can't allocate memory to store device object !!!" << endl;
-				cout << "Exiting" << endl;
+				cout << "Can't allocate memory to store device object !!!" << std::endl;
+				cout << "Exiting" << std::endl;
 			}
 			catch (CORBA::Exception &e)
 			{
 				Tango::Except::print_exception(e);
 				
-				cout << "Received a CORBA_Exception" << endl;
-				cout << "Exiting" << endl;
+				cout << "Received a CORBA_Exception" << std::endl;
+				cout << "Exiting" << std::endl;
 			}
 			Tango::Util::instance()->server_cleanup();
 			return(0);

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/utils/Attributes.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/utils/Attributes.xtend
@@ -228,7 +228,7 @@ class Attributes {
 				{return (static_cast<«cls.name» *>(dev))->is_«attribute.name»_allowed(ty);}
 			«IF attribute.dataType.cppType.toString().contains("Enum")»
 				virtual bool same_type(const type_info &in_type) {return typeid(«attribute.name»Enum) == in_type;}
-				virtual string get_enum_type() {return string("«attribute.name»Enum");}
+				virtual std::string get_enum_type() {return std::string("«attribute.name»Enum");}
 			«ENDIF»
 		};
 		
@@ -242,7 +242,7 @@ class Attributes {
 		class «attribute.name»Attrib: public Tango::FwdAttr
 		{
 		public:
-			«attribute.name»Attrib(const string &_n):FwdAttr(_n) {};
+			«attribute.name»Attrib(const std::string &_n):FwdAttr(_n) {};
 			~«attribute.name»Attrib() {};
 		};
 		
@@ -267,13 +267,13 @@ class Attributes {
 	def Constructor(Attribute attribute, boolean dynamic) '''
 		«IF dynamic»
 			«IF attribute.isScalar»
-				«attribute.name»Attrib(const string &att_name):«attribute.inheritance»(att_name.c_str(), 
+				«attribute.name»Attrib(const std::string &att_name):«attribute.inheritance»(att_name.c_str(), 
 						«attribute.dataType.cppTypeEnum», Tango::«attribute.rwType») {};
 			«ELSEIF attribute.isSpectrum»
-				«attribute.name»Attrib(const string &att_name):«attribute.inheritance»(att_name.c_str(), 
+				«attribute.name»Attrib(const std::string &att_name):«attribute.inheritance»(att_name.c_str(), 
 						«attribute.dataType.cppTypeEnum», Tango::«attribute.rwType», «attribute.maxX») {};
 			«ELSE»
-				«attribute.name»Attrib(const string &att_name):«attribute.inheritance»(att_name.c_str(), 
+				«attribute.name»Attrib(const std::string &att_name):«attribute.inheritance»(att_name.c_str(), 
 						«attribute.dataType.cppTypeEnum», Tango::«attribute.rwType», «attribute.maxX», «attribute.maxY») {};
 			«ENDIF»
 		«ELSE»
@@ -386,7 +386,7 @@ class Attributes {
 		«IF attribute.dataType.cppType.toString().contains("Enum")»
 			«IF attribute.enumLabels!==null && attribute.enumLabels.size>0»
 				{
-					vector<string> labels;
+					vector<std::string> labels;
 					«FOR String label : attribute.enumLabels»
 						labels.push_back("«label»");
 					«ENDFOR»

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/utils/Attributes.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/utils/Attributes.xtend
@@ -145,7 +145,7 @@ class Attributes {
 	def readAttributeMethod(PogoDeviceClass cls, Attribute attribute) '''
 		void «cls.name»::«attribute.readAttrubuteMethod»(Tango::Attribute &attr)
 		{
-			DEBUG_STREAM << "«cls.name»::«attribute.readAttrubuteMethod»(Tango::Attribute &attr) entering... " << endl;
+			DEBUG_STREAM << "«cls.name»::«attribute.readAttrubuteMethod»(Tango::Attribute &attr) entering... " << std::endl;
 			«cls.protectedArea(attribute.readAttrubuteMethod,
 				"//	Set the attribute value\n" +
 				"attr.set_value("+attribute.readAttrubuteDataMember+
@@ -159,7 +159,7 @@ class Attributes {
 	def readDynamicAttributeMethod(PogoDeviceClass cls, Attribute attribute) '''
 		void «cls.name»::«attribute.readAttrubuteMethod»(Tango::Attribute &attr)
 		{
-			DEBUG_STREAM << "«cls.name»::«attribute.readAttrubuteMethod»(Tango::Attribute &attr) entering... " << endl;
+			DEBUG_STREAM << "«cls.name»::«attribute.readAttrubuteMethod»(Tango::Attribute &attr) entering... " << std::endl;
 			«attribute.strType»	*att_value = get_«attribute.name»_data_ptr(attr.get_name());
 			«cls.protectedArea(attribute.readAttrubuteMethod,
 				"//	Set the attribute value\n" +
@@ -173,7 +173,7 @@ class Attributes {
 	def writeAttributeMethod(PogoDeviceClass cls, Attribute attribute) '''
 		void «cls.name»::«attribute.writeAttrubuteMethod»(Tango::WAttribute &attr)
 		{
-			DEBUG_STREAM << "«cls.name»::«attribute.writeAttrubuteMethod»(Tango::WAttribute &attr) entering... " << endl;
+			DEBUG_STREAM << "«cls.name»::«attribute.writeAttrubuteMethod»(Tango::WAttribute &attr) entering... " << std::endl;
 			«IF attribute.isScalar»
 				//	Retrieve write value
 				«IF attribute.dataType.cppType.contains("Enum")»

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/utils/Commands.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/utils/Commands.xtend
@@ -150,7 +150,7 @@ class Commands {
 			«IF command.name.equals("State")»
 				Tango::DevState	argout = Tango::UNKNOWN; // replace by your own algorithm
 			«ELSEIF command.name.equals("Status")»
-				string	status = "Device is OK";
+				std::string	status = "Device is OK";
 			«ENDIF»
 			//	Add your own code
 			

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/utils/Commands.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/utils/Commands.xtend
@@ -141,9 +141,9 @@ class Commands {
 		{
 			«command.argoutDeclaration»
 			«IF command.isDynamic=="true"»
-				DEBUG_STREAM << "«cls.name»::" << command.get_name() << "  - " << device_name << endl;
+				DEBUG_STREAM << "«cls.name»::" << command.get_name() << "  - " << device_name << std::endl;
 			«ELSE»
-				DEBUG_STREAM << "«cls.name»::«command.name»()  - " << device_name << endl;
+				DEBUG_STREAM << "«cls.name»::«command.name»()  - " << device_name << std::endl;
 			«ENDIF»
 			«cls.openProtectedArea(command.execMethod)»
 			
@@ -242,7 +242,7 @@ class Commands {
 		//--------------------------------------------------------
 		CORBA::Any *«command.name»Class::execute(Tango::DeviceImpl *device, «command.classExecuteMethodArgin»
 		{
-			cout2 << "«command.name»Class::execute(): arrived" << endl;
+			cout2 << "«command.name»Class::execute(): arrived" << std::endl;
 			«command.extractArgin»
 			«cls.returnArgout(command)»
 		}

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/utils/CppStringUtils.java
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/utils/CppStringUtils.java
@@ -75,7 +75,7 @@ public class CppStringUtils extends fr.esrf.tango.pogo.generator.common.StringUt
 		String	signature = "void ";
 		if (prototype==false)
 			signature += cls.getName() + "::";
-		signature += "add_" + attribute.getName() + "_dynamic_attribute(string attname";
+		signature += "add_" + attribute.getName() + "_dynamic_attribute(std::string attname";
 		if (isScalar(attribute) == false) {
 			signature += ", " + strType(attribute) + " *ptr";
 			if (prototype)
@@ -91,7 +91,7 @@ public class CppStringUtils extends fr.esrf.tango.pogo.generator.common.StringUt
 		String	signature = "void ";
 		if (prototype==false)
 			signature += cls.getName() + "::";
-		signature += "remove_" + attribute.getName() + "_dynamic_attribute(string attname";
+		signature += "remove_" + attribute.getName() + "_dynamic_attribute(std::string attname";
 		if (isScalar(attribute) == false) {
 			signature += ", bool free_it";
 			if (prototype)
@@ -121,7 +121,7 @@ public class CppStringUtils extends fr.esrf.tango.pogo.generator.common.StringUt
 		String	signature = "void ";
 		if (prototype==false)
 			signature += cls.getName() + "::";
-		signature += "add_" + command.getName() + "_dynamic_command(string cmdname, bool device)";
+		signature += "add_" + command.getName() + "_dynamic_command(std::string cmdname, bool device)";
 		if (prototype)
 			signature += ";";
 		return signature;
@@ -131,7 +131,7 @@ public class CppStringUtils extends fr.esrf.tango.pogo.generator.common.StringUt
 		String	signature = "void ";
 		if (prototype==false)
 			signature += cls.getName() + "::";
-		signature += "remove_" + command.getName() + "_dynamic_command(string cmdname)";
+		signature += "remove_" + command.getName() + "_dynamic_command(std::string cmdname)";
 		if (prototype)
 			signature += ";";
 		return signature;

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/utils/CppTypeDefinitions.java
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/utils/CppTypeDefinitions.java
@@ -92,12 +92,12 @@ public class CppTypeDefinitions {
 		if (propType instanceof FloatType)         return "Tango::DevFloat";
 		if (propType instanceof DoubleType)        return "Tango::DevDouble";
 		if (propType instanceof StringType)        return "string";
-		if (propType instanceof ShortVectorType)   return "vector<Tango::DevShort>";
-		if (propType instanceof IntVectorType)     return "vector<Tango::DevLong>";
-		if (propType instanceof LongVectorType)    return "vector<Tango::DevLong64>";
-		if (propType instanceof FloatVectorType)   return "vector<Tango::DevFloat>";
-		if (propType instanceof DoubleVectorType)  return "vector<Tango::DevDouble>";
-		if (propType instanceof StringVectorType)  return "vector<string>";
+		if (propType instanceof ShortVectorType)   return "std::vector<Tango::DevShort>";
+		if (propType instanceof IntVectorType)     return "std::vector<Tango::DevLong>";
+		if (propType instanceof LongVectorType)    return "std::vector<Tango::DevLong64>";
+		if (propType instanceof FloatVectorType)   return "std::vector<Tango::DevFloat>";
+		if (propType instanceof DoubleVectorType)  return "std::vector<Tango::DevDouble>";
+		if (propType instanceof StringVectorType)  return "std::vector<string>";
 		return "";
 	}
 

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/utils/CppTypeDefinitions.java
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/utils/CppTypeDefinitions.java
@@ -91,13 +91,13 @@ public class CppTypeDefinitions {
 		if (propType instanceof ULongType)         return "Tango::DevULong64";
 		if (propType instanceof FloatType)         return "Tango::DevFloat";
 		if (propType instanceof DoubleType)        return "Tango::DevDouble";
-		if (propType instanceof StringType)        return "string";
+		if (propType instanceof StringType)        return "std::string";
 		if (propType instanceof ShortVectorType)   return "std::vector<Tango::DevShort>";
 		if (propType instanceof IntVectorType)     return "std::vector<Tango::DevLong>";
 		if (propType instanceof LongVectorType)    return "std::vector<Tango::DevLong64>";
 		if (propType instanceof FloatVectorType)   return "std::vector<Tango::DevFloat>";
 		if (propType instanceof DoubleVectorType)  return "std::vector<Tango::DevDouble>";
-		if (propType instanceof StringVectorType)  return "std::vector<string>";
+		if (propType instanceof StringVectorType)  return "std::vector<std::string>";
 		return "";
 	}
 

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/utils/Pipes.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/utils/Pipes.xtend
@@ -90,7 +90,7 @@ class Pipes {
 		class «pipe.name»Class: public Tango::«IF pipe.rwType.contains("WRITE")»W«ENDIF»Pipe
 		{
 		public:
-			«pipe.name»Class(const string &name, Tango::DispLevel level)
+			«pipe.name»Class(const std::string &name, Tango::DispLevel level)
 				:«IF pipe.rwType.contains("WRITE")»W«ENDIF»Pipe(name, level) {};
 		
 			~«pipe.name»Class() {};

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/utils/Pipes.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/utils/Pipes.xtend
@@ -54,7 +54,7 @@ class Pipes {
 		«pipe.pipeMethodHeader("Read")»
 		void «cls.name»::read_«pipe.name»(Tango::Pipe &pipe)
 		{
-			DEBUG_STREAM << "«cls.name»::read_«pipe.name»(Tango::Pipe &pipe) entering... " << endl;
+			DEBUG_STREAM << "«cls.name»::read_«pipe.name»(Tango::Pipe &pipe) entering... " << std::endl;
 			«cls.protectedArea("read_" + pipe.name, "\n//	Add your own code here", false)»
 		}
 	'''
@@ -66,7 +66,7 @@ class Pipes {
 		«pipe.pipeMethodHeader("Write")»
 		void «cls.name»::write_«pipe.name»(Tango::WPipe &pipe)
 		{
-			DEBUG_STREAM << "«cls.name»::write_«pipe.name»(Tango::WPipe &pipe) entering... " << endl;
+			DEBUG_STREAM << "«cls.name»::write_«pipe.name»(Tango::WPipe &pipe) entering... " << std::endl;
 			«cls.protectedArea("write_" + pipe.name, "\n//	Add your own code here", false)»
 		}
 	'''

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/utils/Properties.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/utils/Properties.xtend
@@ -151,7 +151,7 @@ class Properties {
 	def propertyRelatedMethod(PogoDeviceClass cls) '''
 		«cls.simpleMethodHeaderClass("get_class_property",
 			"Get the class property for specified name.")»
-		Tango::DbDatum «cls.name»Class::get_class_property(string &prop_name)
+		Tango::DbDatum «cls.name»Class::get_class_property(std::string &prop_name)
 		{
 			for (unsigned int i=0 ; i<cl_prop.size() ; i++)
 				if (cl_prop[i].name == prop_name)
@@ -162,7 +162,7 @@ class Properties {
 		
 		«cls.simpleMethodHeaderClass("get_default_device_property",
 			"Return the default value for device property.")»
-		Tango::DbDatum «cls.name»Class::get_default_device_property(string &prop_name)
+		Tango::DbDatum «cls.name»Class::get_default_device_property(std::string &prop_name)
 		{
 			for (unsigned int i=0 ; i<dev_def_prop.size() ; i++)
 				if (dev_def_prop[i].name == prop_name)
@@ -173,7 +173,7 @@ class Properties {
 		
 		«cls.simpleMethodHeaderClass("get_default_class_property",
 			"Return the default value for class property.")»
-		Tango::DbDatum «cls.name»Class::get_default_class_property(string &prop_name)
+		Tango::DbDatum «cls.name»Class::get_default_class_property(std::string &prop_name)
 		{
 			for (unsigned int i=0 ; i<cl_def_prop.size() ; i++)
 				if (cl_def_prop[i].name == prop_name)
@@ -226,26 +226,26 @@ class Properties {
 				return;
 		
 			Tango::DbData	data;
-			string	classname = get_name();
-			string	header;
-			string::size_type	start, end;
+			std::string	classname = get_name();
+			std::string	header;
+			std::string::size_type	start, end;
 
 			//	Put title
 			Tango::DbDatum	title("ProjectTitle");
-			string	str_title("«cls.description.title»");
+			std::string	str_title("«cls.description.title»");
 			title << str_title;
 			data.push_back(title);
 		
 			//	Put Description
 			Tango::DbDatum	description("Description");
-			std::vector<string>	str_desc;
+			std::vector<std::string>	str_desc;
 			«cls.description.description.string2Vector("str_desc")»
 			description << str_desc;
 			data.push_back(description);
 		
 			//  Put inheritance
 			Tango::DbDatum	inher_datum("InheritedFrom");
-			std::vector<string> inheritance;
+			std::vector<std::string> inheritance;
 			inheritance.push_back("«DeviceImpl»");
 			inher_datum << inheritance;
 			data.push_back(inher_datum);
@@ -267,10 +267,10 @@ class Properties {
 		)»
 		void «cls.name»Class::set_default_property()
 		{
-			string	prop_name;
-			string	prop_desc;
-			string	prop_def;
-			std::vector<string>	vect_data;
+			std::string	prop_name;
+			std::string	prop_desc;
+			std::string	prop_def;
+			std::vector<std::string>	vect_data;
 
 			//	Set Default Class Properties
 			«FOR Property property : cls.classProperties»

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/utils/Properties.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/utils/Properties.xtend
@@ -238,14 +238,14 @@ class Properties {
 		
 			//	Put Description
 			Tango::DbDatum	description("Description");
-			vector<string>	str_desc;
+			std::vector<string>	str_desc;
 			«cls.description.description.string2Vector("str_desc")»
 			description << str_desc;
 			data.push_back(description);
 		
 			//  Put inheritance
 			Tango::DbDatum	inher_datum("InheritedFrom");
-			vector<string> inheritance;
+			std::vector<string> inheritance;
 			inheritance.push_back("«DeviceImpl»");
 			inher_datum << inheritance;
 			data.push_back(inher_datum);
@@ -270,7 +270,7 @@ class Properties {
 			string	prop_name;
 			string	prop_desc;
 			string	prop_def;
-			vector<string>	vect_data;
+			std::vector<string>	vect_data;
 
 			//	Set Default Class Properties
 			«FOR Property property : cls.classProperties»

--- a/fr.esrf.tango.pogo/src/fr/esrf/tango/pogo/PogoDsl.xtext
+++ b/fr.esrf.tango.pogo/src/fr/esrf/tango/pogo/PogoDsl.xtext
@@ -432,11 +432,11 @@ DevIntType:				{DevIntType} "DevInt";
 EncodedType:			{EncodedType} "DevEncoded";
 EnumType:				{EnumType} "DevEnum";
 
-ShortVectorType:		{ShortVectorType} 	"vector<short>";
-IntVectorType:			{IntVectorType} 	"vector<int>";
-LongVectorType:			{IntVectorType} 	"vector<long>";
-ULongVectorType:		{IntVectorType} 	"vector<ulong>";
-FloatVectorType:		{FloatVectorType} 	"vector<float>";
-DoubleVectorType:		{DoubleVectorType} 	"vector<double>";
-StringVectorType:		{StringVectorType} 	"vector<string>";
+ShortVectorType:		{ShortVectorType} 	"std::vector<short>";
+IntVectorType:			{IntVectorType} 	"std::vector<int>";
+LongVectorType:			{IntVectorType} 	"std::vector<long>";
+ULongVectorType:		{IntVectorType} 	"std::vector<ulong>";
+FloatVectorType:		{FloatVectorType} 	"std::vector<float>";
+DoubleVectorType:		{DoubleVectorType} 	"std::vector<double>";
+StringVectorType:		{StringVectorType} 	"std::vector<string>";
 

--- a/fr.esrf.tango.pogo/src/fr/esrf/tango/pogo/PogoDsl.xtext
+++ b/fr.esrf.tango.pogo/src/fr/esrf/tango/pogo/PogoDsl.xtext
@@ -407,7 +407,7 @@ IntType:				{IntType} "int";
 UIntType:				{UIntType} "uint";
 FloatType:				{FloatType} "float";
 DoubleType:				{DoubleType} "double";
-StringType:				{StringType} "string";
+StringType:				{StringType} "std::string";
 
 CharArrayType:			{CharArrayType} "DevVarCharArray";
 ShortArrayType:			{ShortArrayType} "DevVarShortArray";
@@ -438,5 +438,5 @@ LongVectorType:			{IntVectorType} 	"std::vector<long>";
 ULongVectorType:		{IntVectorType} 	"std::vector<ulong>";
 FloatVectorType:		{FloatVectorType} 	"std::vector<float>";
 DoubleVectorType:		{DoubleVectorType} 	"std::vector<double>";
-StringVectorType:		{StringVectorType} 	"std::vector<string>";
+StringVectorType:		{StringVectorType} 	"std::vector<std::string>";
 

--- a/org.tango.pogo.pogo_gui/src/org/tango/pogo/pogo_gui/PropertyDialog.java
+++ b/org.tango.pogo.pogo_gui/src/org/tango/pogo/pogo_gui/PropertyDialog.java
@@ -629,6 +629,7 @@ public class PropertyDialog extends JDialog {
             return factory.createDoubleVectorType();
         if (tangoType.equals(propertyTypeNames[stringVector]) ||
                 tangoType.toLowerCase().equals("vector<string>") ||
+                tangoType.toLowerCase().equals("vector<std::string>") ||
                 tangoType.equals("DevStringVector") ||    //	Old pogo file
                 tangoType.equals("DevVarStringArray"))    //	Old pogo java file
             return factory.createStringVectorType();

--- a/org.tango.pogo.pogo_gui/src/org/tango/pogo/pogo_gui/PropertyDialog.java
+++ b/org.tango.pogo.pogo_gui/src/org/tango/pogo/pogo_gui/PropertyDialog.java
@@ -578,6 +578,8 @@ public class PropertyDialog extends JDialog {
         //	Old cpp case
         if (tangoType.startsWith("Tango::"))
             tangoType = tangoType.substring("Tango::".length());
+        if (tangoType.startsWith("std::"))
+            tangoType = tangoType.substring("std::".length());
         if (tangoType.equals("void"))
             tangoType = "DevVoid";
 


### PR DESCRIPTION
Add `std::` prefix to:
- cout
- cerr
- endl
- vector
- string
- bad_alloc

I'm not 100% sure about the changes in `org.tango.pogo.pogo_gui/src/org/tango/pogo/pogo_gui/PropertyDialog.java`.
and `fr.esrf.tango.pogo/src/fr/esrf/tango/pogo/PogoDsl.xtext`.

I might still have missed a few changes.
I re-generated TangoTest code and it looked fine.

Fixes #101 