### PR TITLE
Spectrum size

### DIFF
--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/DeviceClassSource.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/DeviceClassSource.xtend
@@ -403,7 +403,12 @@ class DeviceClassSource {
 		//	Initialize pointer for singleton pattern
 		//===================================================================
 		«cls.name»Class *«cls.name»Class::_instance = NULL;
-		
+		//===================================================================
+		//	Class constants
+		//===================================================================
+		«FOR Attribute attribute : cls.attributes»
+			«attribute.readAttributesConstants»
+		«ENDFOR»
 		//--------------------------------------------------------
 		/**
 		 * method : 		«cls.name»Class::«cls.name»Class(std::string &s)

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/utils/Attributes.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/utils/Attributes.xtend
@@ -63,17 +63,32 @@ class Attributes {
 		"read_" + attribute.name
 	}
 	//======================================================
+	def readAttributesConstants(Attribute attribute) {
+		if (attribute.scalar) {
+			""
+		}
+		else
+		if (attribute.spectrum) {
+			"constexpr static long" + attribute.name + "Attrib::X_DATA_SIZE;"
+		}
+		else
+		if (attribute.image) {
+			"constexpr static long" + attribute.name + "Attrib::X_DATA_SIZE;\n" +
+			"constexpr static long" + attribute.name + "Attrib::Y_DATA_SIZE;"
+		}
+	}
+	//======================================================
 	def readAttrubuteSize(Attribute attribute) {
 		if (attribute.scalar) {
 			""
 		}
 		else
 		if (attribute.spectrum) {
-			", " + attribute.maxX
+			", " + attribute.name + "Attrib::X_DATA_SIZE"
 		}
 		else
 		if (attribute.image) {
-			", " + attribute.maxX +", " + attribute.maxY
+			", " + attribute.name +"Attrib::X_DATA_SIZE, " + attribute.name + "Attrib::Y_DATA_SIZE"
 		}
 	}
 	//======================================================
@@ -205,6 +220,19 @@ class Attributes {
 		}
 	'''
 
+	//======================================================
+	// Define constants for attributes
+	//======================================================
+	def attributeConstant(Attribute attribute) '''
+		«IF attribute.isSpectrum»
+			// Constants for «attribute.name» attribute
+			constexpr static long X_DATA_SIZE = «attribute.maxX»;
+		«ELSEIF attribute.isImage»
+			// Constants for «attribute.name» attribute
+			constexpr static long X_DATA_SIZE = «attribute.maxX»;
+			constexpr static long Y_DATA_SIZE = «attribute.maxY»;
+		«ENDIF»
+	'''
 
 	//======================================================
 	// Define attribute classes
@@ -214,6 +242,7 @@ class Attributes {
 		class «attribute.name»Attrib: public Tango::«attribute.inheritance»
 		{
 		public:
+			«attribute.attributeConstant»
 			«attribute.Constructor(dynamic)»
 			~«attribute.name»Attrib() {};
 			«IF attribute.isRead»
@@ -267,14 +296,14 @@ class Attributes {
 	def Constructor(Attribute attribute, boolean dynamic) '''
 		«IF dynamic»
 			«IF attribute.isScalar»
-				«attribute.name»Attrib(const std::string &att_name):«attribute.inheritance»(att_name.c_str(), 
+				«attribute.name»Attrib(const std::string &att_name):«attribute.inheritance»(att_name.c_str(),
 						«attribute.dataType.cppTypeEnum», Tango::«attribute.rwType») {};
 			«ELSEIF attribute.isSpectrum»
-				«attribute.name»Attrib(const std::string &att_name):«attribute.inheritance»(att_name.c_str(), 
-						«attribute.dataType.cppTypeEnum», Tango::«attribute.rwType», «attribute.maxX») {};
+				«attribute.name»Attrib(const std::string &att_name):«attribute.inheritance»(att_name.c_str(),
+						«attribute.dataType.cppTypeEnum», Tango::«attribute.rwType», «attribute.name»Attrib::X_DATA_SIZE) {};
 			«ELSE»
-				«attribute.name»Attrib(const std::string &att_name):«attribute.inheritance»(att_name.c_str(), 
-						«attribute.dataType.cppTypeEnum», Tango::«attribute.rwType», «attribute.maxX», «attribute.maxY») {};
+				«attribute.name»Attrib(const std::string &att_name):«attribute.inheritance»(att_name.c_str(),
+						«attribute.dataType.cppTypeEnum», Tango::«attribute.rwType», «attribute.name»Attrib::X_DATA_SIZE, «attribute.name»Attrib::Y_DATA_SIZE) {};
 			«ENDIF»
 		«ELSE»
 			«IF attribute.isScalar»
@@ -282,10 +311,10 @@ class Attributes {
 						«attribute.dataType.cppTypeEnum», Tango::«attribute.rwType»«attribute.readWithWrite») {};
 			«ELSEIF attribute.isSpectrum»
 				«attribute.name»Attrib():«attribute.inheritance»("«attribute.name»",
-						«attribute.dataType.cppTypeEnum», Tango::«attribute.rwType», «attribute.maxX») {};
+						«attribute.dataType.cppTypeEnum», Tango::«attribute.rwType», «attribute.name»Attrib::X_DATA_SIZE) {};
 			«ELSE»
 				«attribute.name»Attrib():«attribute.inheritance»("«attribute.name»",
-						«attribute.dataType.cppTypeEnum», Tango::«attribute.rwType», «attribute.maxX», «attribute.maxY») {};
+						«attribute.dataType.cppTypeEnum», Tango::«attribute.rwType», «attribute.name»Attrib::X_DATA_SIZE, «attribute.name»Attrib::Y_DATA_SIZE) {};
 			«ENDIF»
 		«ENDIF»
 	'''

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/java/JavaAttribute.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/java/JavaAttribute.xtend
@@ -63,7 +63,20 @@ class JavaAttribute {
 		«ENDFOR»
 	'''
 
-	
+	//======================================================
+	// define code to declare attributes
+	//======================================================
+	def attributeConstant(Attribute attribute) '''
+		«IF attribute.isSpectrum»
+			// Constants for «attribute.getName» attribute
+			private static final int «attribute.getName»_X_DATA_SIZE = «attribute.getMaxX»;
+		«ELSEIF attribute.isImage»
+			// Constants for «attribute.getName» attribute
+			private static final int «attribute.getName»_X_DATA_SIZE = «attribute.getMaxX»;
+			private static final int «attribute.getName»_Y_DATA_SIZE = «attribute.getMaxY»;
+		«ENDIF»
+	'''
+
 	//======================================================
 	// define code to declare attributes
 	//======================================================

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/java/JavaDevice.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/java/JavaDevice.xtend
@@ -109,6 +109,12 @@ class JavaDevice  implements IGenerator {
 			    protected static final Logger logger = LoggerFactory.getLogger(«cls.name».class);
 			    protected static final XLogger xlogger = XLoggerFactory.getXLogger(«cls.name».class);
 			«ENDIF»
+
+			//=========================================
+			// Define constants for attributes
+			//=========================================
+			«cls.attributeConstants»
+
 			//========================================================
 			//	Programmer's data members
 			//========================================================
@@ -233,6 +239,16 @@ class JavaDevice  implements IGenerator {
 				false)»
 	'''
 
+	//======================================================
+	// define constants for attributes
+	//======================================================
+	def attributeConstants(PogoDeviceClass cls) '''
+		«FOR Attribute attribute : cls.attributes»
+			«IF attribute.concreteHere»
+				«attribute.attributeConstant»
+			«ENDIF»
+		«ENDFOR»
+	'''
 
 	//======================================================
 	// define code for class properties

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/java/JavaUtils.java
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/java/JavaUtils.java
@@ -163,11 +163,11 @@ public class JavaUtils extends StringUtils {
 	public String allocation(Attribute attribute) {
 		if (attribute.getAttType().equals("Spectrum"))
 			return " = new " + strJavaType(attribute) + "[" +
-						attribute.getMaxX() + "]";
+						attribute.getName() + "_X_DATA_SIZE]";
 		else
 		if (attribute.getAttType().equals("Image"))
 			return " = new " + strJavaType(attribute) + "[" +
-						attribute.getMaxY() + "][" + attribute.getMaxX() + "]";
+						attribute.getName() + "_Y_DATA_SIZE][" + attribute.getName() + "_X_DATA_SIZE]";
 		else
 		if (attribute.getDataType().toString().contains("String"))
 			return " = \"\"";

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PythonDevice.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PythonDevice.xtend
@@ -107,9 +107,12 @@ class PythonDevice implements IGenerator {
         class «cls.name»Class(«cls.inheritedPythonDeviceClassName»):
             # -------- Add you global class variables here --------------------------
             «cls.protectedArea("global_class_variables")»
-        
+
+            «cls.pythonConstants»
+
             «cls.pythonDynamicAttributesClass»
-        
+
+
         «cls.pythonProperties»
         
         «cls.pythonCommandDefinitions»
@@ -301,6 +304,15 @@ class PythonDevice implements IGenerator {
             «ENDIF»
         «ENDFOR»
         '''
+    //====================================================
+    //    Attributes
+    //====================================================
+    def pythonConstants(PogoDeviceClass cls)'''
+            #    Attributes Constants
+            «FOR attr: cls.attributes»
+                «attr.pythonConstant»
+            «ENDFOR»
+    '''
     //====================================================
     //    Properties
     //====================================================

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PythonUtils.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PythonUtils.xtend
@@ -605,11 +605,11 @@ class PythonUtils {
     
     def String pythonAttributeSize(Attribute attr) {
         if (attr.image) {
-            return ", " + attr.maxX + ", " + attr.maxY;
+            return ", " + attr.name + "_X_DATA_SIZE" + ", " + attr.name + "_Y_DATA_SIZE";
         }
         else
         if (attr.spectrum) {
-            return ", " + attr.maxX;
+            return ", " + attr.name + "_X_DATA_SIZE";
         }
         else
             return "";
@@ -698,8 +698,16 @@ class PythonUtils {
             } ],
             «ELSE»],«ENDIF»
     '''
-    
-    
+    def pythonConstant(Attribute attr) '''
+        «IF attr.spectrum»
+            #    Constants for «attr.name» attribute
+            «attr.name»_X_DATA_SIZE = «attr.maxX»
+        «ELSEIF attr.image»
+            #    Constants for «attr.name» attribute
+            «attr.name»_X_DATA_SIZE = «attr.maxX»
+            «attr.name»_Y_DATA_SIZE = «attr.maxY»
+        «ENDIF»
+    '''
     def pythonAttributeClassHL(Attribute attr) '''
 «attr.name» = attribute(
         dtype=«attr.pythonTypeAttrHL»,


### PR DESCRIPTION
#74 

Example of new code that was generated:
- cpp
```cpp
// Constants for normalImageTest attribute
#define normalImageTest_X_DATA_SIZE 22
#define normalImageTest_Y_DATA_SIZE 54

//	Attribute normalImageTest class definition
class normalImageTestAttrib: public Tango::ImageAttr
{
public:
	normalImageTestAttrib():ImageAttr("normalImageTest",
			Tango::DEV_DOUBLE, Tango::READ, normalImageTest_X_DATA_SIZE, normalImageTest_Y_DATA_SIZE) {};
	~normalImageTestAttrib() {};
	virtual void read(Tango::DeviceImpl *dev,Tango::Attribute &att)
		{(static_cast<Test *>(dev))->read_normalImageTest(att);}
	virtual bool is_allowed(Tango::DeviceImpl *dev,Tango::AttReqType ty)
		{return (static_cast<Test *>(dev))->is_normalImageTest_allowed(ty);}
};
```

- java
```java
//=========================================
// Define constants for attributes
//=========================================
// Constants for testSpectrumAttribute attribute
private static final int testSpectrumAttribute_X_DATA_SIZE = 10;
// Constants for testNormalSpectrum attribute
private static final int testNormalSpectrum_X_DATA_SIZE = 3;
private static final int testNormalSpectrum_Y_DATA_SIZE = 4;

/**
* Attribute testNormalSpectrum, double, Image, READ
* description:
*
*/
@Attribute(name="testNormalSpectrum")
private double[][] testNormalSpectrum = new double[testNormalSpectrum_Y_DATA_SIZE][testNormalSpectrum_X_DATA_SIZE];
```

- python
```python
#    Attributes Constants
#    Constants for normalSpectrum attribute
normalSpectrum_X_DATA_SIZE = 1
#    Constants for normalImage attribute
normalImage_X_DATA_SIZE = 3
normalImage_Y_DATA_SIZE = 4

#    Attribute definitions
attr_list = {
    'normalSpectrum':
        [[PyTango.DevDouble,
          PyTango.SPECTRUM,
          PyTango.READ, normalSpectrum_X_DATA_SIZE]],
    'normalImage':
        [[PyTango.DevDouble,
          PyTango.IMAGE,
          PyTango.READ, normalImage_X_DATA_SIZE, normalImage_Y_DATA_SIZE]],
}
```
- pythonHL - no change I think are needed because currently, this is descriptive enough:
```python
    normalImageAttribute = attribute(
        dtype=(('DevDouble',),),
        max_dim_x=3, max_dim_y=4,
    )
```