### PR TITLE
Remove trailing whitespace for python and c++ generated code (Fix 112)

### DIFF
--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/common/Headers.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/common/Headers.xtend
@@ -53,9 +53,8 @@ class Headers {
 		"// file :        "+ fileName + "\n" +
 		"//\n" +
 		"// description : " + description.comments("//               ") + "\n" +
-		"//\n" +
-		"// project :     " + title + "\n" +
-		"//\n" + licenseText(license, "// ") +
+		"//\n" + projectHeader(title) +
+		"//\n" + licenseText(license, "//") +
 		"//\n" + getCopyrightCommented(copyright) +
 		"//\n" + 
 		"//=============================================================================\n" +
@@ -63,6 +62,17 @@ class Headers {
 		"//        (Program Obviously used to Generate tango Object)\n" +
 		"//=============================================================================\n"
 	}
+	
+	//======================================================
+	// Project header
+	//======================================================
+	def projectHeader(String title) '''
+	    «IF title != ""»
+	        // project :     «title»
+	    «ELSE»
+	        //
+	    «ENDIF»
+	'''
 
 	//======================================================
 	//	Makefile header

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/common/ILicences.java
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/common/ILicences.java
@@ -55,36 +55,36 @@ interface ILicences {
 		if (licence!=null && licence.equals("APACHE"))
 	*/
     static final String	apacheLicenece =
-					"This file is part of Tango device class.\n" +
+					" This file is part of Tango device class.\n" +
 					"\n"+
-					"Tango is free software: you can redistribute it and/or modify\n" +
-					"it under the terms of the APACHE licence.\n";
+					" Tango is free software: you can redistribute it and/or modify\n" +
+					" it under the terms of the APACHE licence.\n";
 		
     static final String	mitLicenece =
-					"This file is part of Tango device class.\n" +
+					" This file is part of Tango device class.\n" +
 					"\n"+
-					"Tango is free software: you can redistribute it and/or modify\n" +
-					"it under the terms of the MIT licence.\n";
+					" Tango is free software: you can redistribute it and/or modify\n" +
+					" it under the terms of the MIT licence.\n";
     
     static final String	bsdLicenece =
-					"This file is part of Tango device class.\n" +
+					" This file is part of Tango device class.\n" +
 					"\n"+
-					"Tango is free software: you can redistribute it and/or modify\n" +
-					"it under the terms of the BSD-3 Clause licence.\n";
+					" Tango is free software: you can redistribute it and/or modify\n" +
+					" it under the terms of the BSD-3 Clause licence.\n";
 
     static final String	gplLicenece =
-					"This file is part of Tango device class.\n" +
+					" This file is part of Tango device class.\n" +
 					"\n"+
-					"Tango is free software: you can redistribute it and/or modify\n" +
-					"it under the terms of the GNU General Public License as published by\n" +
-					"the Free Software Foundation, either version 3 of the License, or\n" +
-					"(at your option) any later version.\n" +
+					" Tango is free software: you can redistribute it and/or modify\n" +
+					" it under the terms of the GNU General Public License as published by\n" +
+					" the Free Software Foundation, either version 3 of the License, or\n" +
+					" (at your option) any later version.\n" +
 					"\n" +
-					"Tango is distributed in the hope that it will be useful,\n" +
-					"but WITHOUT ANY WARRANTY; without even the implied warranty of\n" +
-					"MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\n" +
-					"GNU General Public License for more details.\n" +
+					" Tango is distributed in the hope that it will be useful,\n" +
+					" but WITHOUT ANY WARRANTY; without even the implied warranty of\n" +
+					" MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\n" +
+					" GNU General Public License for more details.\n" +
 					"\n" +
-					"You should have received a copy of the GNU General Public License\n" +
-					"along with Tango.  If not, see <http://www.gnu.org/licenses/>.\n";
+					" You should have received a copy of the GNU General Public License\n" +
+					" along with Tango.  If not, see <http://www.gnu.org/licenses/>.\n";
 }

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/common/StringUtils.java
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/common/StringUtils.java
@@ -179,7 +179,7 @@ public class StringUtils {
 	 */
 	//===========================================================
 	public static String comments(String s, String tag) {
-		return s.replaceAll("\n", "\n"+tag);
+		return s.replace("\n", "\n" + tag);
 	}
 	//===========================================================
 	/**
@@ -492,7 +492,7 @@ public class StringUtils {
 			int start = 0;
 			int end;
 			while ((end=gpl.indexOf(str, start+str.length()))>0) {
-				sb.append(gpl.substring(start, end)).append("Lesser ");
+				sb.append(gpl, start, end).append("Lesser ");
 				start = end;
 			}
 			sb.append(gpl.substring(start));

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/DeviceClassInclude.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/DeviceClassInclude.xtend
@@ -125,12 +125,15 @@ class DeviceClassInclude {
 		class «cls.name»Class : public «cls.inheritedClassNameForDeviceClass»
 		#endif
 		{
-			«cls.protectedAreaClass("Additionnal DServer data members", "", false)»
+			«cls.protectedAreaClass("Additional DServer data members", "Add your own code", true)»
 
 			«cls.classPropertyDeclarations»
-			«cls.publicMethodPrototypes»
-			«cls.protectedMethodPrototypes»
-			«cls.privateMethodPrototypes»
+
+				«cls.publicMethodPrototypes»
+
+				«cls.protectedMethodPrototypes»
+
+				«cls.privateMethodPrototypes»
 		};
 		
 		}	//	End of namespace
@@ -219,7 +222,6 @@ class DeviceClassInclude {
 	// Define public methods prototypes
 	//======================================================
 	def publicMethodPrototypes(PogoDeviceClass cls) '''
-		
 			//	Method prototypes
 			static «cls.name»Class *init(const char *);
 			static «cls.name»Class *instance();
@@ -227,25 +229,23 @@ class DeviceClassInclude {
 			Tango::DbDatum	get_class_property(std::string &);
 			Tango::DbDatum	get_default_device_property(std::string &);
 			Tango::DbDatum	get_default_class_property(std::string &);
-		
 	'''
 	
 	//======================================================
 	// Define protected methods prototypes
 	//======================================================
 	def protectedMethodPrototypes(PogoDeviceClass cls) '''
-		protected:
-			«cls.name»Class(std::string &);
-			static «cls.name»Class *_instance;
-			void command_factory();
-			void attribute_factory(std::vector<Tango::Attr *> &);
-			void pipe_factory();
-			void write_class_property();
-			void set_default_property();
-			void get_class_property();
-			std::string get_cvstag();
-			std::string get_cvsroot();
-		
+			protected:
+				«cls.name»Class(std::string &);
+				static «cls.name»Class *_instance;
+				void command_factory();
+				void attribute_factory(std::vector<Tango::Attr *> &);
+				void pipe_factory();
+				void write_class_property();
+				void set_default_property();
+				void get_class_property();
+				std::string get_cvstag();
+				std::string get_cvsroot();
 	'''
 	
 	//======================================================

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/DeviceClassInclude.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/DeviceClassInclude.xtend
@@ -127,13 +127,11 @@ class DeviceClassInclude {
 		{
 			«cls.protectedAreaClass("Additional DServer data members", "Add your own code", true)»
 
-			«cls.classPropertyDeclarations»
+			«cls.publicMethodPrototypes»
 
-				«cls.publicMethodPrototypes»
+			«cls.protectedMethodPrototypes»
 
-				«cls.protectedMethodPrototypes»
-
-				«cls.privateMethodPrototypes»
+			«cls.privateMethodPrototypes»
 		};
 		
 		}	//	End of namespace
@@ -222,6 +220,8 @@ class DeviceClassInclude {
 	// Define public methods prototypes
 	//======================================================
 	def publicMethodPrototypes(PogoDeviceClass cls) '''
+		public:
+			«cls.classPropertyDeclarations»
 			//	Method prototypes
 			static «cls.name»Class *init(const char *);
 			static «cls.name»Class *instance();
@@ -235,17 +235,17 @@ class DeviceClassInclude {
 	// Define protected methods prototypes
 	//======================================================
 	def protectedMethodPrototypes(PogoDeviceClass cls) '''
-			protected:
-				«cls.name»Class(std::string &);
-				static «cls.name»Class *_instance;
-				void command_factory();
-				void attribute_factory(std::vector<Tango::Attr *> &);
-				void pipe_factory();
-				void write_class_property();
-				void set_default_property();
-				void get_class_property();
-				std::string get_cvstag();
-				std::string get_cvsroot();
+		protected:
+			«cls.name»Class(std::string &);
+			static «cls.name»Class *_instance;
+			void command_factory();
+			void attribute_factory(std::vector<Tango::Attr *> &);
+			void pipe_factory();
+			void write_class_property();
+			void set_default_property();
+			void get_class_property();
+			std::string get_cvstag();
+			std::string get_cvsroot();
 	'''
 	
 	//======================================================

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/DeviceClassSource.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/DeviceClassSource.xtend
@@ -324,7 +324,7 @@ class DeviceClassSource {
 			 * method : 		«cls.name»Class::create_static_attribute_list
 			 * description : 	Create the a list of static attributes
 			 *
-			 * @param	att_list	the ceated attribute list
+			 * @param	att_list	the created attribute list
 			 */
 			//--------------------------------------------------------
 			void «cls.name»Class::create_static_attribute_list(std::vector<Tango::Attr *> &att_list)
@@ -396,7 +396,7 @@ class DeviceClassSource {
 
 
 	//==========================================================
-	// Define singleton constructor, get_intance and init methods
+	// Define singleton constructor, get_instance and init methods
 	//==========================================================
 	def constructors(PogoDeviceClass cls) '''
 		//===================================================================

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/DeviceSource.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/DeviceSource.xtend
@@ -159,7 +159,7 @@ class DeviceSource {
 		{
 			DEBUG_STREAM << "«cls.name»::init_device() create device " << device_name << std::endl;
 			«cls.protectedArea("init_device_before", "Initialization before get_device_property() call", true)»
-			
+
 			«IF cls.hasInheritanceClass»
 				if (Tango::Util::instance()->is_svr_starting() == false  &&
 					Tango::Util::instance()->is_device_restarting(device_name)==false)
@@ -175,6 +175,7 @@ class DeviceSource {
 			«ELSE»
 				//	No device property to be read from database
 			«ENDIF»
+
 			«cls.attributes.allocateAttributeDataMembers»
 			«IF cls.deviceProperties.hasMandatoryProperty»
 				//	No longer if mandatory property not set. 
@@ -299,7 +300,7 @@ class DeviceSource {
 				«FOR Attribute attribute : cls.dynamicAttributes»
 					//	add_«attribute.name»_dynamic_attribute("My«attribute.name»Attribute");
 				«ENDFOR»
-				
+
 			«ENDIF»
 			«cls.protectedArea("add_dynamic_attributes", "Add your own code to create and add dynamic attributes if any", true)»
 		}
@@ -333,7 +334,7 @@ class DeviceSource {
 		{
 			«IF cls.dynamicCommands.size>0»
 				//	Example to add dynamic command:
-				//	Copy inside the folowing protected area to instanciate at startup.
+				//	Copy inside the following protected area to instantiate at startup.
 				«FOR Command command : cls.dynamicCommands»
 					//	add_«command.name»_dynamic_command("My«command.name»Command", true);
 				«ENDFOR»

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/DynamicAttributeUtils.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/DynamicAttributeUtils.xtend
@@ -73,7 +73,7 @@ class DynamicAttributeUtils {
 
 
 		//============================================================
-		//	Tool methods to get pointer on attribute data buffer 
+		//	Tool methods to get pointer on attribute data buffer
 		//============================================================
 		«FOR Attribute attribute : cls.dynamicAttributes»
 			«cls.dynamicAttributeTools(attribute)»
@@ -147,9 +147,9 @@ class DynamicAttributeUtils {
 			«ELSE»
 			    map<std::string,«attribute.strType» *>::iterator ite;
 			«ENDIF»
-		    if ((ite=«attribute.name»_data.find(attname))!=«attribute.name»_data.end())
-		    {
-		    	«cls.protectedArea("remove_" + attribute.name + "_dynamic_attribute")»
+			if ((ite=«attribute.name»_data.find(attname))!=«attribute.name»_data.end())
+			{
+				«cls.protectedArea("remove_" + attribute.name + "_dynamic_attribute", "Add your own code", true)»
 				«IF attribute.attType.equals("Scalar")==false»
 					if (free_it)
 						delete[] ite->second;
@@ -173,19 +173,19 @@ class DynamicAttributeUtils {
 		«attribute.strType» *«cls.name»::get_«attribute.name»_data_ptr(std::string &name)
 		{
 			«IF attribute.isScalar»
-			    map<std::string,«attribute.strType»>::iterator ite;
+				map<std::string,«attribute.strType»>::iterator ite;
 			«ELSE»
-			    map<std::string,«attribute.strType» *>::iterator ite;
+				map<std::string,«attribute.strType» *>::iterator ite;
 			«ENDIF»
-		    if ((ite=«attribute.name»_data.find(name))==«attribute.name»_data.end())
-		    {
+			if ((ite=«attribute.name»_data.find(name))==«attribute.name»_data.end())
+			{
 				TangoSys_OMemStream	tms;
 				tms << "Dynamic attribute " << name << " has not been created";
 				Tango::Except::throw_exception(
 							(const char *)"ATTRIBUTE_NOT_FOUND",
 							tms.str().c_str(),
 							(const char *)"«cls.name»::get_«attribute.name»_data_ptr()");
-		    }
+			}
 			«IF attribute.isScalar»
 				return  &(ite->second);
 			«ELSE»

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/Main.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/Main.xtend
@@ -89,7 +89,7 @@ class Main {
 				//----------------------------------------
 				Tango::Util *tg = Tango::Util::init(argc,argv);
 		
-				// Create the device server singleton 
+				// Create the device server singleton
 				//	which will create everything
 				//----------------------------------------
 				tg->server_init(false);
@@ -107,7 +107,7 @@ class Main {
 			catch (CORBA::Exception &e)
 			{
 				Tango::Except::print_exception(e);
-				
+		
 				std::cout << "Received a CORBA_Exception" << std::endl;
 				std::cout << "Exiting" << std::endl;
 			}

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/utils/Attributes.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/utils/Attributes.xtend
@@ -129,7 +129,6 @@ class Attributes {
 	//	Allocate attribute data members
 	//======================================================
 	def allocateAttributeDataMembers(EList<Attribute> attributes) '''
-
 		«FOR Attribute attribute : attributes»
 			«IF attribute.isConcreteHere»
 				«IF attribute.allocReadMember.isTrue»
@@ -201,7 +200,7 @@ class Attributes {
 				«attribute.name»Enum enum_val[w_length];
 				for (int i=0 ; i<w_length ; i++)  enum_val[i]=(«attribute.name»Enum) w_val[i];
 			«ENDIF»
-			«cls.protectedArea(attribute.writeAttrubuteMethod, "", false)»
+			«cls.protectedArea(attribute.writeAttrubuteMethod, "Add your own code", true)»
 		}
 	'''
 
@@ -267,13 +266,13 @@ class Attributes {
 	def Constructor(Attribute attribute, boolean dynamic) '''
 		«IF dynamic»
 			«IF attribute.isScalar»
-				«attribute.name»Attrib(const std::string &att_name):«attribute.inheritance»(att_name.c_str(), 
+				«attribute.name»Attrib(const std::string &att_name):«attribute.inheritance»(att_name.c_str(),
 						«attribute.dataType.cppTypeEnum», Tango::«attribute.rwType») {};
 			«ELSEIF attribute.isSpectrum»
-				«attribute.name»Attrib(const std::string &att_name):«attribute.inheritance»(att_name.c_str(), 
+				«attribute.name»Attrib(const std::string &att_name):«attribute.inheritance»(att_name.c_str(),
 						«attribute.dataType.cppTypeEnum», Tango::«attribute.rwType», «attribute.maxX») {};
 			«ELSE»
-				«attribute.name»Attrib(const std::string &att_name):«attribute.inheritance»(att_name.c_str(), 
+				«attribute.name»Attrib(const std::string &att_name):«attribute.inheritance»(att_name.c_str(),
 						«attribute.dataType.cppTypeEnum», Tango::«attribute.rwType», «attribute.maxX», «attribute.maxY») {};
 			«ENDIF»
 		«ELSE»
@@ -333,9 +332,8 @@ class Attributes {
 			«attribute.setEventProprty("archive_event_rel_change", attribute.evArchiveCriteria.relChange)»
 			«attribute.setEventProprty("archive_event_abs_change", attribute.evArchiveCriteria.absChange)»
 		«ENDIF»
-
 		«IF cls!==null»
-			«cls.protectedArea("att_" + attribute.name + "_dynamic_attribute", "", false)»
+			«cls.protectedArea("att_" + attribute.name + "_dynamic_attribute", "Add your own code", true)»
 		«ENDIF»
 		«attribute.manageEnumLabels»
 		«attribute.name.toLowerCase»->set_default_properties(«attribute.name.toLowerCase»_prop);

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/utils/CppStringUtils.java
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/utils/CppStringUtils.java
@@ -37,6 +37,8 @@ package fr.esrf.tango.pogo.generator.cpp.utils;
 
 import org.eclipse.emf.common.util.EList;
 import java.util.ArrayList;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import fr.esrf.tango.pogo.generator.common.StringUtils;
 import fr.esrf.tango.pogo.pogoDsl.Command;
@@ -57,8 +59,8 @@ public class CppStringUtils extends fr.esrf.tango.pogo.generator.common.StringUt
 	//	Dynamic attribute headers and signatures
 	//===========================================================
 	public String addDynamicAttributeHeaderComment(Attribute attribute) {
-		 String comment = " *  parameter attname: attribute name to be cretated and added.\n";
-		 if (isScalar(attribute) == false)
+		 String comment = " *  parameter attname: attribute name to be created and added.\n";
+		 if (!isScalar(attribute))
 			 comment += " *  parameter ptr:     memory buffer used to set attribute value.\n" +
 			            " *                     If NULL or not specified, buffer will be allocated.";
 		 return comment;
@@ -66,17 +68,17 @@ public class CppStringUtils extends fr.esrf.tango.pogo.generator.common.StringUt
 	//===========================================================
 	public String removeDynamicAttributeHeaderComment(Attribute attribute) {
 		 String comment = " *  parameter attname: attribute name to be removed.\n";
-		 if (isScalar(attribute) == false)
+		 if (!isScalar(attribute))
 			 comment += " *  parameter free_it: memory buffer will be freed if true or not specified.";
 		 return comment;
 	}
 	//===========================================================
 	public String addDynamicAttributeSignature(PogoDeviceClass cls, Attribute attribute, boolean prototype) {
 		String	signature = "void ";
-		if (prototype==false)
+		if (!prototype)
 			signature += cls.getName() + "::";
 		signature += "add_" + attribute.getName() + "_dynamic_attribute(std::string attname";
-		if (isScalar(attribute) == false) {
+		if (!isScalar(attribute)) {
 			signature += ", " + strType(attribute) + " *ptr";
 			if (prototype)
 				signature += "=NULL";
@@ -89,10 +91,10 @@ public class CppStringUtils extends fr.esrf.tango.pogo.generator.common.StringUt
 	//===========================================================
 	public String removeDynamicAttributeSignature(PogoDeviceClass cls, Attribute attribute, boolean prototype) {
 		String	signature = "void ";
-		if (prototype==false)
+		if (!prototype)
 			signature += cls.getName() + "::";
 		signature += "remove_" + attribute.getName() + "_dynamic_attribute(std::string attname";
-		if (isScalar(attribute) == false) {
+		if (!isScalar(attribute)) {
 			signature += ", bool free_it";
 			if (prototype)
 				signature += "=true";
@@ -107,7 +109,7 @@ public class CppStringUtils extends fr.esrf.tango.pogo.generator.common.StringUt
 	//	Dynamic commands headers and signatures
 	//===========================================================
 	public String addDynamicCommandHeaderComment(Command command) {
-		 String comment = " *  parameter cmdname: command name to be cretated and added.\n"+
+		 String comment = " *  parameter cmdname: command name to be created and added.\n"+
 				 		  " *  parameter device:  Set this flag to true if the command must be added for only this device.\n";
 		 return comment;
 	}
@@ -119,7 +121,7 @@ public class CppStringUtils extends fr.esrf.tango.pogo.generator.common.StringUt
 	//===========================================================
 	public String addDynamicCommandSignature(PogoDeviceClass cls, Command command, boolean prototype) {
 		String	signature = "void ";
-		if (prototype==false)
+		if (!prototype)
 			signature += cls.getName() + "::";
 		signature += "add_" + command.getName() + "_dynamic_command(std::string cmdname, bool device)";
 		if (prototype)
@@ -129,7 +131,7 @@ public class CppStringUtils extends fr.esrf.tango.pogo.generator.common.StringUt
 	//===========================================================
 	public String removeDynamicCommandSignature(PogoDeviceClass cls, Command command, boolean prototype) {
 		String	signature = "void ";
-		if (prototype==false)
+		if (!prototype)
 			signature += cls.getName() + "::";
 		signature += "remove_" + command.getName() + "_dynamic_command(std::string cmdname)";
 		if (prototype)
@@ -146,7 +148,7 @@ public class CppStringUtils extends fr.esrf.tango.pogo.generator.common.StringUt
 	public static String statesTable(EList<State> states) {
 
 		//	Build a list of state columns to build the table
-		ArrayList<String[]>	list = new ArrayList<String[]>();
+		ArrayList<String[]>	list = new ArrayList<>();
 		list.add(new String[] { "================================================================" });
 		list.add(new String[] { "States", "Description" });
 		list.add(new String[] { "================================================================" });
@@ -164,7 +166,7 @@ public class CppStringUtils extends fr.esrf.tango.pogo.generator.common.StringUt
 
 		InheritanceUtils	inher = new InheritanceUtils();
 		//	Build a list of command columns to build the table
-		ArrayList<String[]>	list = new ArrayList<String[]>();
+		ArrayList<String[]>	list = new ArrayList<>();
 		list.add(new String[] { "================================================================" });
 		list.add(new String[] { "  The following table gives the correspondence" });
 		list.add(new String[] { "  between command and method names." });
@@ -193,7 +195,7 @@ public class CppStringUtils extends fr.esrf.tango.pogo.generator.common.StringUt
 		else
 			title += "is:";
 		//	Build a list of command columns to build the table
-		ArrayList<String[]>	list = new ArrayList<String[]>();
+		ArrayList<String[]>	list = new ArrayList<>();
 		list.add(new String[] { "================================================================" });
 		list.add(new String[] { title });
 		list.add(new String[] { "================================================================" });
@@ -201,7 +203,7 @@ public class CppStringUtils extends fr.esrf.tango.pogo.generator.common.StringUt
 			//	Build description
 			String	desc = CppTypeDefinitions.cppType(attribute.getDataType()) + "	" +
 						attribute.getAttType();
-			if (attribute.getAttType().equals("Scalar")==false)
+			if (!attribute.getAttType().equals("Scalar"))
 				desc += "  (" + attTypeDimentions(attribute) + ")";
 
 			list.add(new String[] { attribute.getName(), desc });
@@ -212,24 +214,22 @@ public class CppStringUtils extends fr.esrf.tango.pogo.generator.common.StringUt
 	//===========================================================
 	//===========================================================
 	private static String buildTable(ArrayList<String[]> list) {
-		StringBuffer	sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		//	Get the longest first element
-		int	length = 0;
+		int length = 0;
 		for (String[] array : list) {
-			if (array.length>1)
-				if (array[0].length()>length)
+			if (array.length > 1 && array[0].length() > length)
 					length = array[0].length();
 		}
-		String	emptyTab = "//  ";
-		for (int i=0 ; i<length ; i++)
-			emptyTab += " ";
-		
+		StringBuilder emptyTab = new StringBuilder("//  ");
+		for (int i = 0; i < length; i++)
+			emptyTab.append(" ");
+
 		for (String[] array : list) {
-			if (array.length>1) {
-				String	comments = comments(array[1], emptyTab+"  |  ");
+			if (array.length > 1) {
+				String comments = comments(array[1], emptyTab.append("  |  ").toString());
 				sb.append("//  ").append(buildTab(array[0], length)).append("  |  ").append(comments);
-			}
-			else
+			} else
 				sb.append("//").append(array[0]);
 			sb.append('\n');
 		}
@@ -238,11 +238,9 @@ public class CppStringUtils extends fr.esrf.tango.pogo.generator.common.StringUt
 
 	//===========================================================
 	private static String buildTab(String str, int nbChar) {
-		StringBuffer	sb = new StringBuffer(str);
-		for (int i=str.length() ; i<nbChar ; i++) {
-			sb.append(' ');
-		}
-		return sb.toString();
+		return IntStream.range(str.length(), nbChar)
+				.mapToObj(i -> " ")
+				.collect(Collectors.joining("", str, ""));
 	}
 	//===========================================================
 	public static String readWithWrite(Attribute attribute) {
@@ -266,11 +264,11 @@ public class CppStringUtils extends fr.esrf.tango.pogo.generator.common.StringUt
 	//===========================================================
 	public static String commandParameterHeader(Command command) {
 		String	str = "";
-		if (CppTypeDefinitions.cppType(command.getArgin().getType()).equals("void")==false) {
+		if (!CppTypeDefinitions.cppType(command.getArgin().getType()).equals("void")) {
 			str += " *	@param argin " +
 					StringUtils.comments(command.getArgin().getDescription(), " *               ") + "\n";
 		}
-		if (CppTypeDefinitions.cppType(command.getArgout().getType()).equals("void")==false) {
+		if (!CppTypeDefinitions.cppType(command.getArgout().getType()).equals("void")) {
 			str += " *	@returns " +
 					StringUtils.comments(command.getArgout().getDescription(), " *           ") + "\n";
 		}

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/utils/Headers.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/utils/Headers.xtend
@@ -76,7 +76,7 @@ class Headers extends fr.esrf.tango.pogo.generator.common.Headers{
 			"Include for the " + cls.name +" root class.\n"+
 			"This class is the singleton class for\n"+
 			" the " + cls.name + " device class.\n"+
-			"It contains all properties and methods which the \n" +
+			"It contains all properties and methods which the\n" +
 			cls.name + " requires only once e.g. the commands.",
 			 cls.description.title,
 			cls.description.license,
@@ -223,7 +223,7 @@ class Headers extends fr.esrf.tango.pogo.generator.common.Headers{
 		"//--------------------------------------------------------\n" +
 		"/**\n" +
 		" *	Method      : "+ cls.name + "::" + method + "()\n" +
-		" *	Description : " + description.comments(" *                ") + "\n" +
+		" " + generateMethodDescription(description.comments(" *                ")) +
 		" */\n" +
 		"//--------------------------------------------------------"
 	}
@@ -232,7 +232,7 @@ class Headers extends fr.esrf.tango.pogo.generator.common.Headers{
 		"//--------------------------------------------------------\n" +
 		"/*\n" +
 		" *	Method      : "+ cls.name + "::" + method + "()\n" +
-		" *	Description : " + description.comments(" *                ") + "\n" +
+		" " + generateMethodDescription(description.comments(" *                ")) +
 		" */\n" +
 		"//--------------------------------------------------------"
 	}
@@ -241,7 +241,7 @@ class Headers extends fr.esrf.tango.pogo.generator.common.Headers{
 		"//--------------------------------------------------------\n" +
 		"/**\n" +
 		" *	Method      : "+ cls.name + "Class::" + method + "()\n" +
-		" *	Description : " + description.comments(" *                ") + "\n" +
+		" " + generateMethodDescription(description.comments(" *                ")) +
 		" */\n" +
 		"//--------------------------------------------------------"
 	}
@@ -254,7 +254,7 @@ class Headers extends fr.esrf.tango.pogo.generator.common.Headers{
 		"//--------------------------------------------------------\n" +
 		"/**\n" +
 		" *	" + rw +" attribute " + attr.name + " related method\n" +
-		" *	Description: " + attr.properties.description.comments(" *               ") + "\n" +
+		" " + generateMethodDescription(attr.properties.description.comments(" *               ")) +
 		" *\n" +
 		" *	Data type:	" + attr.dataType.cppType + attr.manageEnumForMethodHeader + "\n" +
 		" *	Attr type:	" + attr.attType + attr.attTypeDimentions + "\n" + 
@@ -269,7 +269,7 @@ class Headers extends fr.esrf.tango.pogo.generator.common.Headers{
 		"//--------------------------------------------------------\n" +
 		"/**\n" +
 		" *	" + rw +" pipe " + pipe.name + " related method\n" +
-		" *	Description: " + pipe.description.comments(" *               ") + "\n" +
+		" " + generateMethodDescription(pipe.description.comments(" *               ")) +
 		" */\n"	+
 		"//--------------------------------------------------------\n"
 	}	
@@ -280,9 +280,9 @@ class Headers extends fr.esrf.tango.pogo.generator.common.Headers{
 	def attributePrototypeMethodHeader(Attribute attr) {
 		"/**\n" +
 		" *	Attribute " + attr.name + " related methods\n" +
-		" *	Description: " + attr.properties.description.comments(" *               ") + "\n" +
+		" " + generateMethodDescription(attr.properties.description.comments(" *               ")) +
 		" *\n" +
-		" *	Data type:	" + attr.dataType.cppType + "\n" +
+		" *	Data type:  " + attr.dataType.cppType + "\n" +
 		" *	Attr type:	" + attr.attType + attr.attTypeDimentions + "\n" + 
 		" */\n"		
 	}
@@ -294,9 +294,17 @@ class Headers extends fr.esrf.tango.pogo.generator.common.Headers{
 	def commandExecutionMethodHeader(Command cmd) {
 		"/**\n" +
 		" *	Command " + cmd.name + " related method\n" +
-		" *	Description: " + cmd.description.comments(" *               ") + "\n" +
+		" " + generateMethodDescription(cmd.description.comments(" *               ")) +
 		" *\n" + cmd.commandParameterHeader +
 		" */\n"		
 	}
+	
+	def generateMethodDescription(String desc) '''
+        «IF desc != ""»
+            * Description:  «desc»
+        «ELSE»
+            *
+        «ENDIF»
+	'''
 
 }

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/utils/Pipes.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/utils/Pipes.xtend
@@ -55,7 +55,7 @@ class Pipes {
 		void «cls.name»::read_«pipe.name»(Tango::Pipe &pipe)
 		{
 			DEBUG_STREAM << "«cls.name»::read_«pipe.name»(Tango::Pipe &pipe) entering... " << std::endl;
-			«cls.protectedArea("read_" + pipe.name, "\n//	Add your own code here", false)»
+			«cls.protectedArea("read_" + pipe.name, "Add your own code here", true)»
 		}
 	'''
 	
@@ -67,7 +67,7 @@ class Pipes {
 		void «cls.name»::write_«pipe.name»(Tango::WPipe &pipe)
 		{
 			DEBUG_STREAM << "«cls.name»::write_«pipe.name»(Tango::WPipe &pipe) entering... " << std::endl;
-			«cls.protectedArea("write_" + pipe.name, "\n//	Add your own code here", false)»
+			«cls.protectedArea("write_" + pipe.name, "Add your own code here", true)»
 		}
 	'''
 	

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/utils/Properties.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/utils/Properties.xtend
@@ -290,18 +290,16 @@ class Properties {
 
 
 	//==========================================================
-	// Define class property related delarations for DeviceClass.cpp
+	// Define class property related declarations for DeviceClass.cpp
 	//==========================================================
 	def classPropertyDeclarations(PogoDeviceClass cls)  '''
-		«IF cls.classProperties.size>0»
-		//	Class properties data members
-		public:
+			«IF cls.classProperties.size>0»
+			//	Class properties data members
 			«FOR Property property : cls.classProperties»
-				//	«property.name»:	«property.description.comments("//  ")»
-				«property.type.cppPropType»	«property.name.dataMemberName»;
+			//	«property.name»:	«property.description.comments("//  ")»
+			«property.type.cppPropType»	«property.name.dataMemberName»;
 			«ENDFOR»
-		«ENDIF»
-		public:
+			«ENDIF»
 			//	write class properties data members
 			Tango::DbData	cl_prop;
 			Tango::DbData	cl_def_prop;

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/utils/ProtectedArea.java
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/cpp/utils/ProtectedArea.java
@@ -68,17 +68,17 @@ public class ProtectedArea {
 	//======================================================================
 	public String protectedArea(PogoDeviceClass cls, String method, String code, boolean comments) {
 		if (comments)
-			return	openProtectedArea(cls, method)+ "\n" +
-					"//	" + CppStringUtils.comments(code, "	//	") + "\n\n" +
+			return openProtectedArea(cls, method) +
+					"//	" + CppStringUtils.comments(code, "	//	") + "\n" +
 					closeProtectedArea(cls, method);
 		else
 			return	openProtectedArea(cls, method) +
-					code + "\n\n" +
+					code + "\n" +
 					closeProtectedArea(cls, method);
 	}
 	//======================================================================
 	public String protectedArea(PogoDeviceClass cls, String method) {
-		return	openProtectedArea(cls.getName(), method)+ "\n" +
+		return openProtectedArea(cls.getName(), method) +
 				closeProtectedArea(cls.getName(), method);
 	}
 	//======================================================================
@@ -94,18 +94,18 @@ public class ProtectedArea {
 	//======================================================================
 	public String protectedAreaClass(PogoDeviceClass cls, String method, String code, boolean comments) {
 		if (comments)
-			return	openProtectedArea(cls.getName()+"Class", method)+ "\n" +
-					"//	" + CppStringUtils.comments(code, "	//	") + "\n\n" +
-					closeProtectedArea(cls.getName()+"Class", method);
+			return openProtectedArea(cls.getName() + "Class", method) +
+					"//	" + CppStringUtils.comments(code, "	//	") + "\n" +
+					closeProtectedArea(cls.getName() + "Class", method);
 		else
 			return	openProtectedArea(cls.getName()+"Class", method) +
-					code + "\n\n" +
+					code + "\n" +
 					closeProtectedArea(cls.getName()+"Class", method);
 	}
 	//======================================================================
 	public String protectedAreaClass(PogoDeviceClass cls, String method) {
-		return	openProtectedArea(cls.getName()+"Class", method)+ "\n" +
-				closeProtectedArea(cls.getName()+"Class", method);
+		return openProtectedArea(cls.getName() + "Class", method) +
+				closeProtectedArea(cls.getName() + "Class", method);
 	}
 
 

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/ProtectedArea.java
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/ProtectedArea.java
@@ -63,9 +63,9 @@ public class ProtectedArea {
 	 */
 	public String openProtectedArea(String className, String method) {
 		if (method.startsWith("."))	//	Not method, it is a file name
-			return "#----- PROTECTED REGION ID(" + className + method + ") ENABLED START -----#\n";
+			return "#----- PROTECTED REGION ID(" + className + method + ") ENABLED START -----#";
 		else
-			return "#----- PROTECTED REGION ID(" + className + "." + method + ") ENABLED START -----#\n";
+			return "#----- PROTECTED REGION ID(" + className + "." + method + ") ENABLED START -----#";
 	}
 	/**
 	 * CLose protected area
@@ -99,11 +99,11 @@ public class ProtectedArea {
 	public String protectedArea(PogoDeviceClass cls, String method, String code, boolean comments) {
 		if (comments)
 			return	openProtectedArea(cls, method)+ "\n" +
-					"#	" + StringUtils.comments(code, "	#	") + "\n\n" +
+					"#	" + StringUtils.comments(code, "	#	") + "\n" +
 					closeProtectedArea(cls, method);
 		else
 			return	openProtectedArea(cls, method) +
-					code + "\n\n" +
+					code + "\n" +
 					closeProtectedArea(cls, method);
 	}
 	/**

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PythonDevice.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PythonDevice.xtend
@@ -379,9 +379,9 @@ class PythonDevice implements IGenerator {
                 U.server_run()
         
             except PyTango.DevFailed as e:
-                print ('-------> Received a DevFailed exception:', e)
+                print('-------> Received a DevFailed exception:', e)
             except Exception as e:
-                print ('-------> An unforeseen exception occurred....', e)
+                print('-------> An unforeseen exception occurred....', e)
         
         
         if __name__ == '__main__':

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PythonDevice.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PythonDevice.xtend
@@ -81,24 +81,16 @@ class PythonDevice implements IGenerator {
         
         class «cls.name» («cls.inheritedPythonClassName»):
             """«cls.description.description»"""
-
-            # -------- Add you global variables here --------------------------
-            «cls.protectedArea("global_variables")»
-        
-            «cls.pythonConstructors»
-
-            «cls.pythonDeleteDevice»
-
-            «cls.pythonInitDevice»
-        
-            def always_executed_hook(self):
-                self.debug_stream("In always_excuted_hook()")
-                «cls.protectedArea("always_executed_hook")»
+        «cls.pythonClassHeader»
+        «cls.pythonConstructors»
+        «cls.pythonDeleteDevice»
+        «cls.pythonInitDevice»
+        «cls.pythonAlwaysExecutedHook»
         «cls.pythonAttributes»
-        
-            «cls.pythonCommands»
-
-            «cls.protectedArea("programmer_methods")»
+        «cls.pythonDynamicAttributes»
+        «cls.pythonReadAttrHardware»
+        «cls.pythonCommands»
+        «cls.pythonClassFooter»
     '''
 
     //====================================================
@@ -170,25 +162,28 @@ class PythonDevice implements IGenerator {
     //    Constructors
     //====================================================
     def pythonConstructors(PogoDeviceClass cls)  '''
-            def __init__(self, cl, name):
-                «cls.inheritedConstructor»
-                self.debug_stream("In __init__()")
-                «cls.name».init_device(self)
-                «cls.protectedArea("__init__")»
+    
+        def __init__(self, cl, name):
+            «cls.inheritedConstructor»
+            self.debug_stream("In __init__()")
+            «cls.name».init_device(self)
+            «cls.protectedArea("__init__")»
     '''
 
     //====================================================
     //    Delete device method
     //====================================================
     def pythonDeleteDevice(PogoDeviceClass cls)  '''
-            def delete_device(self):
-                self.debug_stream("In delete_device()")
-                «cls.protectedArea("delete_device")»
+    
+        def delete_device(self):
+            self.debug_stream("In delete_device()")
+            «cls.protectedArea("delete_device")»
     '''
     //====================================================
     //    Constructors
     //====================================================
     def pythonInitDevice(PogoDeviceClass cls)  '''
+    
         def init_device(self):
             self.debug_stream("In init_device()")
             self.get_device_properties(self.get_device_class())
@@ -210,22 +205,18 @@ class PythonDevice implements IGenerator {
         «FOR attr: cls.attributes»
         «IF isTrue(attr.status.concreteHere)»
         «IF attr.isRead»
-        «readAttributeMethod(cls, attr)»
 
+        «readAttributeMethod(cls, attr)»
         «ENDIF»
         «IF attr.isWrite»
-        «writeAttributeMethod(cls, attr)»
 
+        «writeAttributeMethod(cls, attr)»
         «ENDIF»
         «IF !attr.readExcludedStates.empty || !attr.writeExcludedStates.empty»
         «attributeMethodStateMachine(cls, attr)»
         «ENDIF»
         «ENDIF»
         «ENDFOR»
-    «cls.pythonDynamicAttributes»
-        def read_attr_hardware(self, data):
-            self.debug_stream("In read_attr_hardware()")
-            «cls.protectedArea("read_attr_hardware")»
     '''
     //====================================================
     //    Dynamic Attributes
@@ -247,13 +238,12 @@ class PythonDevice implements IGenerator {
         «ENDIF»
         «ENDIF»
         «ENDFOR»
-
         «IF !cls.dynamicAttributes.empty»
         def initialize_dynamic_attributes(self):
             self.debug_stream("In initialize_dynamic_attributes()")
 
             #   Example to add dynamic attributes
-            #   Copy inside the folowing protected area to instanciate at startup.
+            #   Copy inside the following protected area to instantiate at startup.
 
             «FOR attr : cls.dynamicAttributes»
                 """   For Attribute «attr.name»
@@ -264,7 +254,43 @@ class PythonDevice implements IGenerator {
             «ENDFOR»
             «cls.protectedArea("initialize_dynamic_attributes")»
         «ENDIF»
-
+    '''
+    
+    //====================================================
+    //    Read Attr Hardware method for class
+    //====================================================
+    def pythonClassHeader(PogoDeviceClass cls)  '''
+    
+        # -------- Add you global variables here --------------------------
+        «cls.openProtectedArea("global_variables")»
+    '''
+    
+    //====================================================
+    //    Read Attr Hardware method for class
+    //====================================================
+    def pythonReadAttrHardware(PogoDeviceClass cls)  '''
+    
+        def read_attr_hardware(self, data):
+            self.debug_stream("In read_attr_hardware()")
+            «cls.protectedArea("read_attr_hardware")»
+    '''
+    
+    //====================================================
+    //    Always Executed Hook method for class
+    //====================================================
+    def pythonAlwaysExecutedHook(PogoDeviceClass cls)  '''
+    
+        def always_executed_hook(self):
+            self.debug_stream("In always_excuted_hook()")
+            «cls.protectedArea("always_executed_hook")»
+    '''
+    
+    //====================================================
+    //    Read Attr Hardware method for class
+    //====================================================
+    def pythonClassFooter(PogoDeviceClass cls)  '''
+    
+        «cls.protectedArea("programmer_methods")»
     '''
 
     //====================================================
@@ -292,17 +318,19 @@ class PythonDevice implements IGenerator {
         «ENDIF»
     '''
 
+    //====================================================
     //    Commands
     //====================================================
     def pythonCommands(PogoDeviceClass cls)  '''
-        # -------------------------------------------------------------------------
-        #    «cls.name» command methods
-        # -------------------------------------------------------------------------
-            «FOR cmd: cls.commands»
+        
+            # -------------------------------------------------------------------------
+            #    «cls.name» command methods
+            # -------------------------------------------------------------------------
+        «FOR cmd: cls.commands»
             «IF isTrue(cmd.status.concreteHere)»
-        «commandExecution(cls, cmd)»
+                    «commandExecution(cls, cmd)»
                 «IF !cmd.excludedStates.empty»
-        «commandMethodStateMachine(cls, cmd)»
+                    «commandMethodStateMachine(cls, cmd)»
                 «ENDIF»
             «ENDIF»
         «ENDFOR»

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PythonDevice.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PythonDevice.xtend
@@ -321,7 +321,6 @@ class PythonDevice implements IGenerator {
                 }
             «cls.inheritanceClassPropertyList»
         
-        
             #    Device Properties
             device_property_list = {
                 «FOR prop : cls.deviceProperties»
@@ -382,7 +381,8 @@ class PythonDevice implements IGenerator {
             except PyTango.DevFailed as e:
                 print ('-------> Received a DevFailed exception:', e)
             except Exception as e:
-                print ('-------> An unforeseen exception occured....', e)
+                print ('-------> An unforeseen exception occurred....', e)
+        
         
         if __name__ == '__main__':
             main()

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PythonDevice.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PythonDevice.xtend
@@ -133,9 +133,8 @@ class PythonDevice implements IGenerator {
         #
         #  File :        «cls.name + ".py"»
         #
-        #  Project :     «cls.description.title»
-        #
-        «cls.description.license.licenseText("# ")»
+        «projectTittle(cls)»
+        «cls.description.license.licenseText("#")»
         #
         #  $Author :      «cls.description.identification.author»$
         #

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PythonDeviceHL.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PythonDeviceHL.xtend
@@ -199,7 +199,8 @@ class «cls.name»(«cls.inheritedPythonClassNameHL»):
     //    File header
     //====================================================
     def pythonHeader(PogoDeviceClass cls) '''
-""" «cls.description.title»
+"""
+«cls.description.title»
 
 «cls.description.description»
 """

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PythonUtils.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PythonUtils.xtend
@@ -329,7 +329,6 @@ class PythonUtils {
 		    «IF !cmd.argout.type.voidType»argout = «cmd.argout.type.defaultValue»«ENDIF»
 		    «protectedArea(cls, cmd.name)»
 		    «cmd.returnMethodCode»
-
         '''
 
     def projectTittle(PogoDeviceClass cls) '''

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PythonUtils.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PythonUtils.xtend
@@ -329,7 +329,16 @@ class PythonUtils {
 		    «IF !cmd.argout.type.voidType»argout = «cmd.argout.type.defaultValue»«ENDIF»
 		    «protectedArea(cls, cmd.name)»
 		    «cmd.returnMethodCode»
-		    
+
+        '''
+
+    def projectTittle(PogoDeviceClass cls) '''
+            «IF cls.description.title != ""»
+            #  Project :     «cls.description.title»
+            #
+            «ELSE»
+            #
+            «ENDIF»
         '''
         
     def commandExecutionHL(PogoDeviceClass cls, Command cmd) '''

--- a/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PythonUtils.xtend
+++ b/fr.esrf.tango.generator.xtend/src/fr/esrf/tango/pogo/generator/python/PythonUtils.xtend
@@ -412,7 +412,6 @@ class PythonUtils {
 		    self.debug_stream("In write_«attribute.name»()")
 		    data = attr.get_write_value()
 		    «protectedArea(cls, attribute.name + "_write")»
-		    
     '''
     def writeAttributeMethodHL(PogoDeviceClass cls, Attribute attribute, boolean isDynamic) '''
         def write_«attribute.name»(self, «IF isDynamic»w_attr«ELSE»value«ENDIF»):
@@ -434,14 +433,12 @@ class PythonUtils {
                 «ELSE»
                 pass
                 «ENDIF»
-
     '''
         
     def readAttributeMethod(PogoDeviceClass cls, Attribute attribute) '''
 		def read_«attribute.name»(self, attr):
 		    self.debug_stream("In read_«attribute.name»()")
 		    «protectedArea(cls, attribute.name + "_read", attribute.setAttrVal, false)»
-		    
     '''
     def readAttributeMethodHL(PogoDeviceClass cls, Attribute attribute, boolean isDynamic) '''
         def read_«attribute.name»(self«IF isDynamic», attr«ENDIF»):
@@ -465,7 +462,6 @@ class PythonUtils {
                 «ELSE»
                 return «attribute.defaultValueDim»
                 «ENDIF»
-
     '''
       
     def readPipeMethodHL(PogoDeviceClass cls, Pipe pip) '''


### PR DESCRIPTION
#112 

This commit changes a little bit the PR for c++, in most cases, we will have:

```cpp
/*----- PROTECTED REGION ID(Test::write_spectrumDynamicTest) ENABLED START -----*/
//	Add your own code
/*----- PROTECTED REGION END -----*/	//	Test::write_spectrumDynamicTest
```

Or:

```cpp
/*----- PROTECTED REGION ID(Test::write_spectrumDynamicTest) ENABLED START -----*/
/*----- PROTECTED REGION END -----*/	//	Test::write_spectrumDynamicTest
```

To get rid of trailing whitespace from PR blocks.